### PR TITLE
feat: Task b577yQCU — videoAnalytics document type for YouTube stats

### DIFF
--- a/lib/types/video-analytics.ts
+++ b/lib/types/video-analytics.ts
@@ -1,0 +1,18 @@
+export interface VideoAnalytics {
+  _id: string;
+  _type: 'videoAnalytics';
+  _createdAt: string;
+  _updatedAt: string;
+  contentRef: {
+    _type: 'reference';
+    _ref: string;
+  };
+  contentType: 'post' | 'podcast' | 'automatedVideo';
+  youtubeId: string;
+  youtubeShortId?: string;
+  viewCount: number;
+  likeCount: number;
+  commentCount: number;
+  favoriteCount: number;
+  lastFetchedAt?: string;
+}

--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -48,6 +48,7 @@ import sponsorshipRequest from "@/sanity/schemas/documents/sponsorshipRequest";
 import contentIdea from "@/sanity/schemas/documents/contentIdea";
 import automatedVideo from "@/sanity/schemas/documents/automatedVideo";
 import mediaAsset from "@/sanity/schemas/documents/mediaAsset";
+import videoAnalytics from "@/sanity/schemas/documents/videoAnalytics";
 import sponsorLead from "@/sanity/schemas/documents/sponsorLead";
 import sponsorPool from "@/sanity/schemas/documents/sponsorPool";
 import tableSchema, { rowType } from "@/sanity/schemas/custom/table";
@@ -152,6 +153,7 @@ export default defineConfig({
       contentIdea,
       automatedVideo,
       mediaAsset,
+      videoAnalytics,
       sponsorLead,
       sponsorPool,
     ],

--- a/sanity/schemas/documents/videoAnalytics.ts
+++ b/sanity/schemas/documents/videoAnalytics.ts
@@ -1,6 +1,10 @@
 import { defineField, defineType } from 'sanity';
 import { HiOutlineChartBar } from 'react-icons/hi';
 
+// One videoAnalytics document per content document (1:1 relationship).
+// Sanity cannot enforce uniqueness at schema level — the CF Worker cron
+// that creates these docs must check for existing docs before creating:
+//   *[_type == "videoAnalytics" && contentRef._ref == $docId][0]
 export default defineType({
   name: 'videoAnalytics',
   title: 'Video Analytics',
@@ -32,6 +36,7 @@ export default defineType({
         ],
       },
       validation: (Rule) => Rule.required(),
+      readOnly: true,
     }),
     defineField({
       name: 'youtubeId',
@@ -39,6 +44,7 @@ export default defineType({
       type: 'string',
       description: 'YouTube video ID (e.g., dQw4w9WgXcQ)',
       validation: (Rule) => Rule.required(),
+      readOnly: true,
     }),
     defineField({
       name: 'youtubeShortId',

--- a/sanity/schemas/documents/videoAnalytics.ts
+++ b/sanity/schemas/documents/videoAnalytics.ts
@@ -1,0 +1,114 @@
+import { defineField, defineType } from 'sanity';
+import { HiOutlineChartBar } from 'react-icons/hi';
+
+export default defineType({
+  name: 'videoAnalytics',
+  title: 'Video Analytics',
+  type: 'document',
+  icon: HiOutlineChartBar,
+  fields: [
+    defineField({
+      name: 'contentRef',
+      title: 'Content Reference',
+      type: 'reference',
+      to: [
+        { type: 'post' },
+        { type: 'podcast' },
+        { type: 'automatedVideo' },
+      ],
+      description: 'The content document these analytics belong to',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'contentType',
+      title: 'Content Type',
+      type: 'string',
+      description: 'Denormalized content type for efficient GROQ filtering without dereferencing',
+      options: {
+        list: [
+          { title: 'Post', value: 'post' },
+          { title: 'Podcast', value: 'podcast' },
+          { title: 'Automated Video', value: 'automatedVideo' },
+        ],
+      },
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'youtubeId',
+      title: 'YouTube Video ID',
+      type: 'string',
+      description: 'YouTube video ID (e.g., dQw4w9WgXcQ)',
+      validation: (Rule) => Rule.required(),
+    }),
+    defineField({
+      name: 'youtubeShortId',
+      title: 'YouTube Short ID',
+      type: 'string',
+      description: 'YouTube Short video ID (for automatedVideo with both formats)',
+    }),
+    defineField({
+      name: 'viewCount',
+      title: 'View Count',
+      type: 'number',
+      description: 'YouTube view count',
+      initialValue: 0,
+      readOnly: true,
+    }),
+    defineField({
+      name: 'likeCount',
+      title: 'Like Count',
+      type: 'number',
+      description: 'YouTube like count',
+      initialValue: 0,
+      readOnly: true,
+    }),
+    defineField({
+      name: 'commentCount',
+      title: 'Comment Count',
+      type: 'number',
+      description: 'YouTube comment count',
+      initialValue: 0,
+      readOnly: true,
+    }),
+    defineField({
+      name: 'favoriteCount',
+      title: 'Favorite Count',
+      type: 'number',
+      description: 'YouTube favorite count',
+      initialValue: 0,
+      readOnly: true,
+    }),
+    defineField({
+      name: 'lastFetchedAt',
+      title: 'Last Fetched At',
+      type: 'datetime',
+      description: 'When stats were last pulled from the YouTube Data API',
+      readOnly: true,
+    }),
+  ],
+  orderings: [
+    {
+      title: 'Views (High to Low)',
+      name: 'viewCountDesc',
+      by: [{ field: 'viewCount', direction: 'desc' }],
+    },
+    {
+      title: 'Last Fetched',
+      name: 'lastFetchedAtDesc',
+      by: [{ field: 'lastFetchedAt', direction: 'desc' }],
+    },
+  ],
+  preview: {
+    select: {
+      contentType: 'contentType',
+      youtubeId: 'youtubeId',
+      viewCount: 'viewCount',
+    },
+    prepare({ contentType, youtubeId, viewCount }) {
+      return {
+        title: youtubeId || 'No YouTube ID',
+        subtitle: `${contentType || 'unknown'} · ${(viewCount ?? 0).toLocaleString()} views`,
+      };
+    },
+  },
+});


### PR DESCRIPTION
## Task b577yQCU: YouTube Stats Document Type

Adds a `videoAnalytics` Sanity document type that stores YouTube statistics separately from content documents. This eliminates webhook noise when stats are updated and drops the Supabase dependency for stats storage.

### New Files
- `sanity/schemas/documents/videoAnalytics.ts` (115 lines) — Document schema
- `lib/types/video-analytics.ts` (19 lines) — TypeScript interface

### Updated Files
- `sanity.config.ts` — Register `videoAnalytics` in schema types

### Schema Fields
| Field | Type | Description |
|-------|------|-------------|
| `contentRef` | reference (post/podcast/automatedVideo) | Back-reference to the content document |
| `contentType` | string enum | Denormalized type for efficient GROQ filtering without dereferencing |
| `youtubeId` | string (required) | YouTube video ID |
| `youtubeShortId` | string (optional) | YouTube Short ID for dual-format videos |
| `viewCount` | number (readOnly) | YouTube view count |
| `likeCount` | number (readOnly) | YouTube like count |
| `commentCount` | number (readOnly) | YouTube comment count |
| `favoriteCount` | number (readOnly) | YouTube favorite count |
| `lastFetchedAt` | datetime (readOnly) | When stats were last pulled from YouTube API |

### Design Decisions
- **1:1 relationship** — One `videoAnalytics` doc per content doc, linked via `contentRef`
- **Denormalized `contentType`** — Per @seniordeveloper's suggestion, enables `*[_type == "videoAnalytics" && contentType == "podcast"]` without dereferencing (faster filtered leaderboards)
- **Stats fields are `readOnly`** — Only the CF Worker cron should update these, not manual Studio edits
- **`youtubeShortId` optional** — Only `automatedVideo` docs have both horizontal + short versions

### Webhook Filter Note
⚠️ **Sanity webhook GROQ filters for the content-engine pipeline should EXCLUDE `videoAnalytics`** to prevent stats updates from triggering the content pipeline. Recommended filter:

```groq
_type == "automatedVideo" && !(_type == "videoAnalytics")
```

Or more explicitly, the existing webhook filter `_type == "automatedVideo"` already excludes `videoAnalytics` since they're different document types. No webhook changes needed — just documenting for clarity.

### NOT in scope (handled by other tasks)
- `lib/youtube-stats.ts` rewrite → Backlog task `M6yODRZI` (CF Worker cron)
- GROQ query migration → @seniordeveloper Task `vmJFtHej` (page migration)
- Removing `statistics` from content partial → Task 1F (cleanup after migration proven)

### GROQ Query Pattern (for reference)
```groq
// Top content by views (filtered by type)
*[_type == "videoAnalytics" && contentType == "podcast" && viewCount > 0] 
  | order(viewCount desc)[0...4] {
    viewCount,
    "content": contentRef-> { title, slug, coverImage, date, _type }
  }
```