### PR TITLE
feat: Batch 2 page migration — author, guest, sponsor pages

### DIFF
--- a/apps/web/src/components/PersonDetail.astro
+++ b/apps/web/src/components/PersonDetail.astro
@@ -1,0 +1,106 @@
+---
+import { PortableText } from "astro-portabletext";
+import { urlForImage } from "@/utils/sanity";
+import ContentCard from "./ContentCard.astro";
+
+interface Props {
+  person: any;
+  type: "author" | "guest" | "sponsor";
+}
+
+const { person, type } = Astro.props;
+
+const coverUrl = person.coverImage
+  ? urlForImage(person.coverImage).width(400).height(400).format("webp").url()
+  : null;
+---
+
+<div class="flex flex-col md:flex-row gap-8 mb-12">
+  {coverUrl && (
+    <img
+      src={coverUrl}
+      alt={person.title}
+      width={400}
+      height={400}
+      class="w-48 h-48 rounded-full object-cover flex-shrink-0"
+    />
+  )}
+  <div>
+    <h1 class="text-4xl font-bold mb-4">{person.title}</h1>
+    {person.excerpt && (
+      <p class="text-gray-600 text-lg mb-4">{person.excerpt}</p>
+    )}
+    {person.socials && (
+      <div class="flex flex-wrap gap-3">
+        {person.socials.twitter && (
+          <a href={`https://twitter.com/${person.socials.twitter}`} target="_blank" rel="noopener noreferrer" class="text-blue-500 hover:underline">
+            Twitter
+          </a>
+        )}
+        {person.socials.github && (
+          <a href={`https://github.com/${person.socials.github}`} target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:underline">
+            GitHub
+          </a>
+        )}
+        {person.socials.linkedin && (
+          <a href={person.socials.linkedin} target="_blank" rel="noopener noreferrer" class="text-blue-700 hover:underline">
+            LinkedIn
+          </a>
+        )}
+      </div>
+    )}
+    {person.websites && person.websites.length > 0 && (
+      <div class="flex flex-wrap gap-3 mt-2">
+        {person.websites.map((site: string) => (
+          <a href={site} target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:underline text-sm">
+            {new URL(site).hostname}
+          </a>
+        ))}
+      </div>
+    )}
+  </div>
+</div>
+
+{person.content && (
+  <div class="prose prose-lg max-w-none mb-12">
+    <PortableText value={person.content} />
+  </div>
+)}
+
+{person.related && (
+  <>
+    {person.related.podcast && person.related.podcast.length > 0 && (
+      <section class="mb-12">
+        <h2 class="text-2xl font-bold mb-6">Related Podcasts</h2>
+        <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
+          {person.related.podcast.map((p: any) => (
+            <ContentCard
+              title={p.title}
+              slug={`/podcast/${p.slug}`}
+              coverImage={p.coverImage}
+              excerpt={p.excerpt}
+              date={p.date}
+            />
+          ))}
+        </div>
+      </section>
+    )}
+
+    {person.related.post && person.related.post.length > 0 && (
+      <section class="mb-12">
+        <h2 class="text-2xl font-bold mb-6">Related Posts</h2>
+        <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
+          {person.related.post.map((p: any) => (
+            <ContentCard
+              title={p.title}
+              slug={`/post/${p.slug}`}
+              coverImage={p.coverImage}
+              excerpt={p.excerpt}
+              date={p.date}
+            />
+          ))}
+        </div>
+      </section>
+    )}
+  </>
+)}

--- a/apps/web/src/components/PersonDetail.astro
+++ b/apps/web/src/components/PersonDetail.astro
@@ -13,6 +13,11 @@ const { person, type } = Astro.props;
 const coverUrl = person.coverImage
   ? urlForImage(person.coverImage).width(400).height(400).format("webp").url()
   : null;
+
+function getHostname(url: string): string {
+  try { return new URL(url).hostname; }
+  catch { return url; }
+}
 ---
 
 <div class="flex flex-col md:flex-row gap-8 mb-12">
@@ -53,7 +58,7 @@ const coverUrl = person.coverImage
       <div class="flex flex-wrap gap-3 mt-2">
         {person.websites.map((site: string) => (
           <a href={site} target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:underline text-sm">
-            {new URL(site).hostname}
+            {getHostname(site)}
           </a>
         ))}
       </div>

--- a/apps/web/src/layouts/BaseLayout.astro
+++ b/apps/web/src/layouts/BaseLayout.astro
@@ -25,6 +25,7 @@ const { title, description = "CodingCat.dev — Purrfect Web Tutorials" } = Astr
         <div class="flex items-center gap-6">
           <a href="/blog" class="hover:text-blue-600 transition-colors">Blog</a>
           <a href="/podcasts" class="hover:text-blue-600 transition-colors">Podcasts</a>
+          <a href="/authors" class="hover:text-blue-600 transition-colors">Authors</a>
           <a href="/dashboard" class="hover:text-blue-600 transition-colors">Dashboard</a>
         </div>
       </nav>

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -118,3 +118,69 @@ export const settingsQuery = groq`*[_type == "settings"][0]{
   ...,
   ogImage
 }`;
+
+// Author queries
+export const authorListQuery = groq`*[_type == "author" && defined(slug.current)] | order(title) [$offset...$end] {
+  ${baseFields}
+}`;
+
+export const authorCountQuery = groq`count(*[_type == "author" && defined(slug.current)])`;
+
+export const authorQuery = groq`*[_type == "author" && slug.current == $slug][0] {
+  ${baseFields},
+  ${contentFields},
+  socials,
+  websites,
+  "related": {
+    "podcast": *[_type == "podcast" && (^._id in author[]._ref || ^._id in guest[]._ref)] | order(date desc) [0...4] {
+      ${baseFields}
+    },
+    "post": *[_type == "post" && (^._id in author[]._ref || ^._id in guest[]._ref)] | order(date desc) [0...4] {
+      ${baseFields}
+    },
+  }
+}`;
+
+// Guest queries
+export const guestListQuery = groq`*[_type == "guest" && defined(slug.current)] | order(title) [$offset...$end] {
+  ${baseFields}
+}`;
+
+export const guestCountQuery = groq`count(*[_type == "guest" && defined(slug.current)])`;
+
+export const guestQuery = groq`*[_type == "guest" && slug.current == $slug][0] {
+  ${baseFields},
+  ${contentFields},
+  socials,
+  websites,
+  "related": {
+    "podcast": *[_type == "podcast" && (^._id in author[]._ref || ^._id in guest[]._ref)] | order(date desc) [0...4] {
+      ${baseFields}
+    },
+    "post": *[_type == "post" && (^._id in author[]._ref || ^._id in guest[]._ref)] | order(date desc) [0...4] {
+      ${baseFields}
+    },
+  }
+}`;
+
+// Sponsor queries
+export const sponsorListQuery = groq`*[_type == "sponsor" && defined(slug.current)] | order(date desc) [$offset...$end] {
+  ${baseFields}
+}`;
+
+export const sponsorCountQuery = groq`count(*[_type == "sponsor" && defined(slug.current)])`;
+
+export const sponsorQuery = groq`*[_type == "sponsor" && slug.current == $slug][0] {
+  ${baseFields},
+  ${contentFields},
+  socials,
+  websites,
+  "related": {
+    "podcast": *[_type == "podcast" && ^._id in sponsor[]._ref] | order(date desc) [0...4] {
+      ${baseFields}
+    },
+    "post": *[_type == "post" && ^._id in sponsor[]._ref] | order(date desc) [0...4] {
+      ${baseFields}
+    },
+  }
+}`;

--- a/apps/web/src/pages/author/[slug].astro
+++ b/apps/web/src/pages/author/[slug].astro
@@ -1,0 +1,21 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import PersonDetail from "@/components/PersonDetail.astro";
+import { sanityFetch } from "@/utils/sanity";
+import { authorQuery } from "@/lib/queries";
+
+export const prerender = false;
+
+const { slug } = Astro.params;
+const author = await sanityFetch<any>(authorQuery, { slug });
+
+if (!author) {
+  return Astro.redirect("/404");
+}
+---
+
+<BaseLayout title={`${author.title} — CodingCat.dev`} description={author.excerpt}>
+  <main class="container mx-auto px-4 py-8 max-w-4xl">
+    <PersonDetail person={author} type="author" />
+  </main>
+</BaseLayout>

--- a/apps/web/src/pages/authors.astro
+++ b/apps/web/src/pages/authors.astro
@@ -1,0 +1,48 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import ContentCard from "@/components/ContentCard.astro";
+import Pagination from "@/components/Pagination.astro";
+import { sanityFetch } from "@/utils/sanity";
+import { authorListQuery, authorCountQuery } from "@/lib/queries";
+
+export const prerender = false;
+
+const rawPage = Number(Astro.url.searchParams.get("page") || "1");
+const page = Number.isNaN(rawPage) || rawPage < 1 ? 1 : Math.floor(rawPage);
+const perPage = 12;
+const offset = (page - 1) * perPage;
+
+const [items, totalCount] = await Promise.all([
+  sanityFetch<any[]>(authorListQuery, { offset, end: offset + perPage }),
+  sanityFetch<number>(authorCountQuery),
+]);
+
+const totalPages = Math.ceil(totalCount / perPage);
+
+if (page > totalPages && totalPages > 0) {
+  return Astro.redirect(`/authors?page=${totalPages}`);
+}
+---
+
+<BaseLayout title="Authors — CodingCat.dev">
+  <main class="container mx-auto px-4 py-8">
+    <h1 class="text-4xl font-bold mb-2">Authors</h1>
+    <p class="text-gray-600 mb-8">The people behind CodingCat.dev content.</p>
+
+    <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+      {items?.map((item) => (
+        <ContentCard
+          title={item.title}
+          slug={`/author/${item.slug}`}
+          coverImage={item.coverImage}
+          excerpt={item.excerpt}
+          date={item.date}
+        />
+      ))}
+    </div>
+
+    {totalPages > 1 && (
+      <Pagination currentPage={page} totalPages={totalPages} basePath="/authors" />
+    )}
+  </main>
+</BaseLayout>

--- a/apps/web/src/pages/guest/[slug].astro
+++ b/apps/web/src/pages/guest/[slug].astro
@@ -1,0 +1,21 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import PersonDetail from "@/components/PersonDetail.astro";
+import { sanityFetch } from "@/utils/sanity";
+import { guestQuery } from "@/lib/queries";
+
+export const prerender = false;
+
+const { slug } = Astro.params;
+const guest = await sanityFetch<any>(guestQuery, { slug });
+
+if (!guest) {
+  return Astro.redirect("/404");
+}
+---
+
+<BaseLayout title={`${guest.title} — CodingCat.dev`} description={guest.excerpt}>
+  <main class="container mx-auto px-4 py-8 max-w-4xl">
+    <PersonDetail person={guest} type="guest" />
+  </main>
+</BaseLayout>

--- a/apps/web/src/pages/guests.astro
+++ b/apps/web/src/pages/guests.astro
@@ -1,0 +1,48 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import ContentCard from "@/components/ContentCard.astro";
+import Pagination from "@/components/Pagination.astro";
+import { sanityFetch } from "@/utils/sanity";
+import { guestListQuery, guestCountQuery } from "@/lib/queries";
+
+export const prerender = false;
+
+const rawPage = Number(Astro.url.searchParams.get("page") || "1");
+const page = Number.isNaN(rawPage) || rawPage < 1 ? 1 : Math.floor(rawPage);
+const perPage = 12;
+const offset = (page - 1) * perPage;
+
+const [items, totalCount] = await Promise.all([
+  sanityFetch<any[]>(guestListQuery, { offset, end: offset + perPage }),
+  sanityFetch<number>(guestCountQuery),
+]);
+
+const totalPages = Math.ceil(totalCount / perPage);
+
+if (page > totalPages && totalPages > 0) {
+  return Astro.redirect(`/guests?page=${totalPages}`);
+}
+---
+
+<BaseLayout title="Guests — CodingCat.dev">
+  <main class="container mx-auto px-4 py-8">
+    <h1 class="text-4xl font-bold mb-2">Guests</h1>
+    <p class="text-gray-600 mb-8">The people behind CodingCat.dev content.</p>
+
+    <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+      {items?.map((item) => (
+        <ContentCard
+          title={item.title}
+          slug={`/guest/${item.slug}`}
+          coverImage={item.coverImage}
+          excerpt={item.excerpt}
+          date={item.date}
+        />
+      ))}
+    </div>
+
+    {totalPages > 1 && (
+      <Pagination currentPage={page} totalPages={totalPages} basePath="/guests" />
+    )}
+  </main>
+</BaseLayout>

--- a/apps/web/src/pages/sponsor/[slug].astro
+++ b/apps/web/src/pages/sponsor/[slug].astro
@@ -1,0 +1,21 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import PersonDetail from "@/components/PersonDetail.astro";
+import { sanityFetch } from "@/utils/sanity";
+import { sponsorQuery } from "@/lib/queries";
+
+export const prerender = false;
+
+const { slug } = Astro.params;
+const sponsor = await sanityFetch<any>(sponsorQuery, { slug });
+
+if (!sponsor) {
+  return Astro.redirect("/404");
+}
+---
+
+<BaseLayout title={`${sponsor.title} — CodingCat.dev`} description={sponsor.excerpt}>
+  <main class="container mx-auto px-4 py-8 max-w-4xl">
+    <PersonDetail person={sponsor} type="sponsor" />
+  </main>
+</BaseLayout>

--- a/apps/web/src/pages/sponsors.astro
+++ b/apps/web/src/pages/sponsors.astro
@@ -1,0 +1,48 @@
+---
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import ContentCard from "@/components/ContentCard.astro";
+import Pagination from "@/components/Pagination.astro";
+import { sanityFetch } from "@/utils/sanity";
+import { sponsorListQuery, sponsorCountQuery } from "@/lib/queries";
+
+export const prerender = false;
+
+const rawPage = Number(Astro.url.searchParams.get("page") || "1");
+const page = Number.isNaN(rawPage) || rawPage < 1 ? 1 : Math.floor(rawPage);
+const perPage = 12;
+const offset = (page - 1) * perPage;
+
+const [items, totalCount] = await Promise.all([
+  sanityFetch<any[]>(sponsorListQuery, { offset, end: offset + perPage }),
+  sanityFetch<number>(sponsorCountQuery),
+]);
+
+const totalPages = Math.ceil(totalCount / perPage);
+
+if (page > totalPages && totalPages > 0) {
+  return Astro.redirect(`/sponsors?page=${totalPages}`);
+}
+---
+
+<BaseLayout title="Sponsors — CodingCat.dev">
+  <main class="container mx-auto px-4 py-8">
+    <h1 class="text-4xl font-bold mb-2">Sponsors</h1>
+    <p class="text-gray-600 mb-8">The sponsors supporting CodingCat.dev content.</p>
+
+    <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+      {items?.map((item) => (
+        <ContentCard
+          title={item.title}
+          slug={`/sponsor/${item.slug}`}
+          coverImage={item.coverImage}
+          excerpt={item.excerpt}
+          date={item.date}
+        />
+      ))}
+    </div>
+
+    {totalPages > 1 && (
+      <Pagination currentPage={page} totalPages={totalPages} basePath="/sponsors" />
+    )}
+  </main>
+</BaseLayout>


### PR DESCRIPTION
# Batch 2: People & Sponsors Page Migration

Migrates author, guest, and sponsor pages from Next.js to Astro. Completes the `/author/[slug]` and `/guest/[slug]` links from Batch 1.

## Pages (6)

| Route | Type | Description |
|-------|------|-------------|
| `/authors` | Listing | Paginated authors (alphabetical) |
| `/author/[slug]` | Detail | Author profile + related podcasts/posts |
| `/guests` | Listing | Paginated guests (alphabetical) |
| `/guest/[slug]` | Detail | Guest profile + related podcasts/posts |
| `/sponsors` | Listing | Paginated sponsors (by date) |
| `/sponsor/[slug]` | Detail | Sponsor profile + related podcasts/posts |

## Shared Component

**`PersonDetail.astro`** — Reusable detail layout for all three person types:
- Cover image (400×400 WebP, rounded)
- Social links (Twitter, GitHub, LinkedIn)
- Website links (auto-extracted hostname)
- Portable Text content
- Related podcasts grid (up to 4)
- Related posts grid (up to 4)

## GROQ Queries (9 new)

| Query | Purpose |
|-------|---------|
| `authorListQuery` | Paginated author listing |
| `authorCountQuery` | Total author count |
| `authorQuery` | Author detail + related content (podcasts/posts where author appears) |
| `guestListQuery` | Paginated guest listing |
| `guestCountQuery` | Total guest count |
| `guestQuery` | Guest detail + related content |
| `sponsorListQuery` | Paginated sponsor listing |
| `sponsorCountQuery` | Total sponsor count |
| `sponsorQuery` | Sponsor detail + related content (podcasts/posts where sponsor appears) |

## Patterns (same as Batch 1)

- ✅ Page validation (NaN/negative → page 1, overflow → redirect to last page)
- ✅ `$offset...$end` GROQ pagination
- ✅ `description={item.excerpt}` on detail pages
- ✅ ContentCard + Pagination component reuse
- ✅ `export const prerender = false` on all pages
- ✅ 404 redirect when detail item not found

## Build

17.5s ✅ (11 total pages now)

## Nav

Added "Authors" link to header navigation.