### PR TITLE
feat: design system foundation — tokens, dark mode, components, layout

### DIFF
--- a/apps/web/src/components/Avatar.astro
+++ b/apps/web/src/components/Avatar.astro
@@ -1,0 +1,35 @@
+---
+interface Props {
+  src?: string;
+  name: string;
+  size?: "xs" | "sm" | "md" | "lg" | "xl";
+}
+
+const { src, name, size = "md" } = Astro.props;
+
+const sizeMap: Record<string, string> = {
+  xs: "w-6 h-6 text-[10px]",
+  sm: "w-8 h-8 text-xs",
+  md: "w-10 h-10 text-sm",
+  lg: "w-16 h-16 text-xl",
+  xl: "w-24 h-24 text-3xl",
+};
+
+const initials = name
+  .split(" ")
+  .map((n) => n[0])
+  .join("")
+  .slice(0, 2)
+  .toUpperCase();
+---
+
+<div class:list={[
+  "relative rounded-full overflow-hidden bg-primary/20 flex items-center justify-center flex-shrink-0",
+  sizeMap[size],
+]}>
+  {src ? (
+    <img src={src} alt={name} class="w-full h-full object-cover" loading="lazy" />
+  ) : (
+    <span class="font-semibold text-primary">{initials}</span>
+  )}
+</div>

--- a/apps/web/src/components/Badge.astro
+++ b/apps/web/src/components/Badge.astro
@@ -1,0 +1,37 @@
+---
+interface Props {
+  type: "blog" | "podcast" | "course" | "video" | "short";
+  size?: "sm" | "md";
+}
+
+const { type, size = "md" } = Astro.props;
+
+const colors: Record<string, string> = {
+  blog: "bg-[--color-type-blog]/15 text-[--color-type-blog] border-[--color-type-blog]/25",
+  podcast: "bg-[--color-type-podcast]/15 text-[--color-type-podcast] border-[--color-type-podcast]/25",
+  course: "bg-[--color-type-course]/15 text-[--color-type-course] border-[--color-type-course]/25",
+  video: "bg-[--color-type-video]/15 text-[--color-type-video] border-[--color-type-video]/25",
+  short: "bg-[--color-type-short]/15 text-[--color-type-short] border-[--color-type-short]/25",
+};
+
+const labels: Record<string, string> = {
+  blog: "Blog",
+  podcast: "Podcast",
+  course: "Course",
+  video: "Video",
+  short: "Short",
+};
+
+const sizes: Record<string, string> = {
+  sm: "px-1.5 py-0.5 text-[10px]",
+  md: "px-2 py-0.5 text-xs",
+};
+---
+
+<span class:list={[
+  "inline-flex items-center font-semibold uppercase tracking-wider rounded-sm border",
+  colors[type],
+  sizes[size],
+]}>
+  {labels[type]}
+</span>

--- a/apps/web/src/components/Button.astro
+++ b/apps/web/src/components/Button.astro
@@ -1,0 +1,39 @@
+---
+interface Props {
+  variant?: "primary" | "secondary" | "ghost" | "destructive";
+  size?: "sm" | "md" | "lg";
+  href?: string;
+  class?: string;
+  [key: string]: any;
+}
+
+const { variant = "primary", size = "md", href, class: className, ...rest } = Astro.props;
+
+const baseClasses = "inline-flex items-center justify-center font-medium transition-colors duration-150 disabled:opacity-50 disabled:pointer-events-none";
+
+const variantClasses = {
+  primary: "bg-primary text-white hover:bg-primary-hover focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[--bg]",
+  secondary: "border border-[--border] text-[--text] hover:bg-[--surface-hover] hover:border-[--border-hover]",
+  ghost: "text-[--text-secondary] hover:text-[--text] hover:bg-[--surface-hover]",
+  destructive: "bg-destructive text-white hover:bg-destructive-hover",
+};
+
+const sizeClasses = {
+  sm: "px-3 py-1.5 text-sm rounded-md gap-1.5",
+  md: "px-4 py-2 text-sm rounded-lg gap-2",
+  lg: "px-6 py-3 text-base rounded-lg gap-2",
+};
+
+const classes = [baseClasses, variantClasses[variant], sizeClasses[size], className].filter(Boolean).join(" ");
+const Tag = href ? "a" : "button";
+---
+
+{href ? (
+  <a href={href} class={classes} {...rest}>
+    <slot />
+  </a>
+) : (
+  <button class={classes} {...rest}>
+    <slot />
+  </button>
+)}

--- a/apps/web/src/components/Container.astro
+++ b/apps/web/src/components/Container.astro
@@ -1,0 +1,19 @@
+---
+interface Props {
+  size?: "default" | "narrow" | "wide" | "full";
+  class?: string;
+}
+
+const { size = "default", class: className } = Astro.props;
+
+const sizes: Record<string, string> = {
+  narrow: "max-w-3xl",
+  default: "max-w-6xl",
+  wide: "max-w-7xl",
+  full: "max-w-none",
+};
+---
+
+<div class:list={["mx-auto px-4 sm:px-6 lg:px-8", sizes[size], className]}>
+  <slot />
+</div>

--- a/apps/web/src/components/ContentCard.astro
+++ b/apps/web/src/components/ContentCard.astro
@@ -1,49 +1,62 @@
 ---
+import Badge from "./Badge.astro";
+import Avatar from "./Avatar.astro";
 import { urlForImage } from "@/utils/sanity";
 
 interface Props {
   title: string;
-  slug: string;
-  coverImage?: any;
-  excerpt?: string;
-  date?: string;
+  url: string;
+  type: "blog" | "podcast" | "course" | "video" | "short";
+  thumbnail?: any;
+  duration?: string;
+  metadata?: string;
+  authorName?: string;
+  authorImage?: any;
 }
 
-const { title, slug, coverImage, excerpt, date } = Astro.props;
+const { title, url, type, thumbnail, duration, metadata, authorName, authorImage } = Astro.props;
 
-const imageUrl = coverImage
-  ? urlForImage(coverImage).width(640).height(360).format("webp").url()
-  : null;
-
-const formattedDate = date
-  ? new Date(date).toLocaleDateString("en-US", {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-    })
-  : null;
+const thumbnailUrl = thumbnail ? urlForImage(thumbnail).width(640).height(360).url() : undefined;
+const authorImageUrl = authorImage ? urlForImage(authorImage).width(48).height(48).url() : undefined;
 ---
 
-<a href={slug} class="group block rounded-lg border hover:border-blue-500 transition-colors overflow-hidden">
-  {imageUrl && (
-    <img
-      src={imageUrl}
-      alt={title}
-      width={640}
-      height={360}
-      class="w-full aspect-video object-cover"
-      loading="lazy"
-    />
+<a href={url} class="group block rounded-xl border border-[--border] bg-[--surface] overflow-hidden transition-all duration-200 hover:border-[--border-hover] hover:shadow-[--shadow-glow] hover:-translate-y-0.5">
+  {/* Thumbnail */}
+  {thumbnailUrl && (
+    <div class="relative aspect-video overflow-hidden">
+      <img
+        src={thumbnailUrl}
+        alt={title}
+        class="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
+        loading="lazy"
+      />
+      {duration && (
+        <span class="absolute bottom-2 right-2 bg-black/80 text-white text-xs font-mono px-1.5 py-0.5 rounded-sm">
+          {duration}
+        </span>
+      )}
+    </div>
   )}
-  <div class="p-4">
-    <h3 class="font-semibold text-lg group-hover:text-blue-600 transition-colors line-clamp-2">
+
+  {/* Content */}
+  <div class="p-4 space-y-2">
+    {/* Badge + Metadata Row */}
+    <div class="flex items-center gap-2 text-xs">
+      <Badge type={type} />
+      {metadata && <span class="text-[--text-tertiary]">{metadata}</span>}
+    </div>
+
+    {/* Title */}
+    <h3 class="font-semibold text-[--text] line-clamp-2 group-hover:text-primary transition-colors">
       {title}
     </h3>
-    {excerpt && (
-      <p class="text-gray-600 text-sm mt-2 line-clamp-2">{excerpt}</p>
-    )}
-    {formattedDate && (
-      <time datetime={date} class="text-gray-400 text-xs mt-2 block">{formattedDate}</time>
+
+    {/* Author */}
+    {authorName && (
+      <div class="flex items-center gap-2">
+        <Avatar src={authorImageUrl} name={authorName} size="xs" />
+        <span class="text-sm text-[--text-secondary]">{authorName}</span>
+      </div>
     )}
   </div>
 </a>

--- a/apps/web/src/components/ContentCardCompact.astro
+++ b/apps/web/src/components/ContentCardCompact.astro
@@ -1,0 +1,46 @@
+---
+import Badge from "./Badge.astro";
+import Avatar from "./Avatar.astro";
+import { urlForImage } from "@/utils/sanity";
+
+interface Props {
+  title: string;
+  url: string;
+  type: "blog" | "podcast" | "course" | "video" | "short";
+  thumbnail?: any;
+  metadata?: string;
+  authorName?: string;
+  authorImage?: any;
+}
+
+const { title, url, type, thumbnail, metadata, authorName, authorImage } = Astro.props;
+
+const thumbnailUrl = thumbnail ? urlForImage(thumbnail).width(192).height(128).url() : undefined;
+const authorImageUrl = authorImage ? urlForImage(authorImage).width(32).height(32).url() : undefined;
+---
+
+<a href={url} class="group flex gap-3 p-3 rounded-lg border border-[--border] bg-[--surface] transition-all duration-200 hover:border-[--border-hover] hover:bg-[--surface-hover]">
+  {thumbnailUrl && (
+    <div class="relative w-24 h-16 rounded-md overflow-hidden flex-shrink-0">
+      <img src={thumbnailUrl} alt={title} class="w-full h-full object-cover" loading="lazy" />
+    </div>
+  )}
+
+  <div class="flex-1 min-w-0 space-y-1">
+    <div class="flex items-center gap-2 text-xs">
+      <Badge type={type} size="sm" />
+      {metadata && <span class="text-[--text-tertiary]">{metadata}</span>}
+    </div>
+
+    <h4 class="font-medium text-sm text-[--text] line-clamp-1 group-hover:text-primary transition-colors">
+      {title}
+    </h4>
+
+    {authorName && (
+      <div class="flex items-center gap-1.5">
+        <Avatar src={authorImageUrl} name={authorName} size="xs" />
+        <span class="text-xs text-[--text-tertiary]">{authorName}</span>
+      </div>
+    )}
+  </div>
+</a>

--- a/apps/web/src/components/ContentCardFeatured.astro
+++ b/apps/web/src/components/ContentCardFeatured.astro
@@ -1,0 +1,77 @@
+---
+import Badge from "./Badge.astro";
+import Avatar from "./Avatar.astro";
+import { urlForImage } from "@/utils/sanity";
+
+interface Props {
+  title: string;
+  url: string;
+  type: "blog" | "podcast" | "course" | "video" | "short";
+  thumbnail?: any;
+  duration?: string;
+  metadata?: string;
+  excerpt?: string;
+  authorName?: string;
+  authorImage?: any;
+  guestName?: string;
+  guestImage?: any;
+}
+
+const {
+  title, url, type, thumbnail, duration, metadata, excerpt,
+  authorName, authorImage, guestName, guestImage,
+} = Astro.props;
+
+const thumbnailUrl = thumbnail ? urlForImage(thumbnail).width(800).height(450).url() : undefined;
+const authorImageUrl = authorImage ? urlForImage(authorImage).width(64).height(64).url() : undefined;
+const guestImageUrl = guestImage ? urlForImage(guestImage).width(64).height(64).url() : undefined;
+---
+
+<a href={url} class="group block rounded-xl border border-[--border] bg-[--surface] overflow-hidden transition-all duration-200 hover:border-primary/50 hover:shadow-[--shadow-glow] md:flex md:gap-6 p-4 md:p-6">
+  {/* Thumbnail */}
+  {thumbnailUrl && (
+    <div class="relative aspect-video md:w-1/2 rounded-lg overflow-hidden flex-shrink-0">
+      <img
+        src={thumbnailUrl}
+        alt={title}
+        class="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
+      />
+      {duration && (
+        <span class="absolute bottom-2 right-2 bg-black/80 text-white text-xs font-mono px-2 py-1 rounded-sm">
+          {duration}
+        </span>
+      )}
+    </div>
+  )}
+
+  {/* Content */}
+  <div class="mt-4 md:mt-0 flex flex-col justify-center space-y-3">
+    <div class="flex items-center gap-2 text-sm">
+      <Badge type={type} />
+      {metadata && <span class="text-[--text-tertiary]">{metadata}</span>}
+    </div>
+
+    <h2 class="text-2xl md:text-3xl font-bold text-[--text] group-hover:text-primary transition-colors">
+      {title}
+    </h2>
+
+    {excerpt && (
+      <p class="text-[--text-secondary] line-clamp-2 md:line-clamp-3">{excerpt}</p>
+    )}
+
+    <div class="flex items-center gap-3">
+      {authorName && (
+        <>
+          <Avatar src={authorImageUrl} name={authorName} size="sm" />
+          <span class="text-sm text-[--text-secondary]">{authorName}</span>
+        </>
+      )}
+      {guestName && (
+        <>
+          <Avatar src={guestImageUrl} name={guestName} size="sm" />
+          <span class="text-sm text-[--text-secondary]">{guestName}</span>
+        </>
+      )}
+    </div>
+  </div>
+</a>

--- a/apps/web/src/components/Footer.astro
+++ b/apps/web/src/components/Footer.astro
@@ -1,0 +1,80 @@
+---
+import Container from "./Container.astro";
+
+/**
+ * Site footer with brand column, content links, connect links, legal links,
+ * and compact newsletter signup.
+ */
+---
+
+<footer class="border-t border-[--border] bg-[--bg-secondary] mt-16">
+  <Container>
+    <div class="py-12 md:py-16">
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
+        {/* Brand Column */}
+        <div class="lg:col-span-1 space-y-4">
+          <a href="/" class="flex items-center gap-2 font-bold text-lg text-[--text]">
+            <span class="text-2xl">🐱</span>
+            CodingCat<span class="text-primary">.dev</span>
+          </a>
+          <p class="text-sm text-[--text-secondary]">
+            Purrfect Web Development Tutorials — blog posts, podcasts, courses, and videos.
+          </p>
+          {/* Compact newsletter */}
+          <form class="flex gap-2">
+            <input
+              type="email"
+              placeholder="you@example.com"
+              class="flex-1 px-3 py-2 text-sm rounded-lg border border-[--border] bg-[--bg] text-[--text] placeholder:text-[--text-tertiary] focus:outline-none focus:ring-2 focus:ring-primary/50"
+            />
+            <button
+              type="submit"
+              class="px-3 py-2 bg-primary text-white text-sm font-medium rounded-lg hover:bg-primary-hover transition-colors"
+            >
+              →
+            </button>
+          </form>
+        </div>
+
+        {/* Content Links */}
+        <div>
+          <h4 class="font-semibold text-sm text-[--text] mb-3">Content</h4>
+          <ul class="space-y-2">
+            <li><a href="/blog" class="text-sm text-[--text-secondary] hover:text-[--text] transition-colors">Blog</a></li>
+            <li><a href="/podcasts" class="text-sm text-[--text-secondary] hover:text-[--text] transition-colors">Podcast</a></li>
+            <li><a href="/authors" class="text-sm text-[--text-secondary] hover:text-[--text] transition-colors">Authors</a></li>
+            <li><a href="/guests" class="text-sm text-[--text-secondary] hover:text-[--text] transition-colors">Guests</a></li>
+          </ul>
+        </div>
+
+        {/* Connect Links */}
+        <div>
+          <h4 class="font-semibold text-sm text-[--text] mb-3">Connect</h4>
+          <ul class="space-y-2">
+            <li><a href="https://youtube.com/@codingcatdev" class="text-sm text-[--text-secondary] hover:text-[--text] transition-colors" target="_blank" rel="noopener">YouTube</a></li>
+            <li><a href="https://twitter.com/codingcatdev" class="text-sm text-[--text-secondary] hover:text-[--text] transition-colors" target="_blank" rel="noopener">Twitter / X</a></li>
+            <li><a href="https://github.com/codingcatdev" class="text-sm text-[--text-secondary] hover:text-[--text] transition-colors" target="_blank" rel="noopener">GitHub</a></li>
+            <li><a href="/rss.xml" class="text-sm text-[--text-secondary] hover:text-[--text] transition-colors">RSS Feed</a></li>
+          </ul>
+        </div>
+
+        {/* Legal Links */}
+        <div>
+          <h4 class="font-semibold text-sm text-[--text] mb-3">Legal</h4>
+          <ul class="space-y-2">
+            <li><a href="/privacy" class="text-sm text-[--text-secondary] hover:text-[--text] transition-colors">Privacy Policy</a></li>
+            <li><a href="/terms" class="text-sm text-[--text-secondary] hover:text-[--text] transition-colors">Terms of Service</a></li>
+            <li><a href="/sponsors" class="text-sm text-[--text-secondary] hover:text-[--text] transition-colors">Sponsors</a></li>
+          </ul>
+        </div>
+      </div>
+
+      {/* Copyright */}
+      <div class="mt-12 pt-6 border-t border-[--border] text-center">
+        <p class="text-sm text-[--text-tertiary]">
+          &copy; {new Date().getFullYear()} CodingCat.dev. All rights reserved.
+        </p>
+      </div>
+    </div>
+  </Container>
+</footer>

--- a/apps/web/src/components/Header.astro
+++ b/apps/web/src/components/Header.astro
@@ -1,0 +1,170 @@
+---
+import Container from "./Container.astro";
+import ThemeToggle from "./ThemeToggle.astro";
+
+/**
+ * Sticky header with logo, navigation, search trigger, theme toggle, and mobile hamburger.
+ * Navigation links are hardcoded for now — will be driven by Sanity settings.navLinks later.
+ */
+
+const navLinks = [
+  { title: "Blog", path: "/blog" },
+  { title: "Podcasts", path: "/podcasts" },
+  { title: "Authors", path: "/authors" },
+];
+
+const currentPath = Astro.url.pathname;
+---
+
+<header class="sticky top-0 z-50 border-b border-[--border] bg-[--bg]/80 backdrop-blur-xl">
+  <Container>
+    <nav class="flex items-center justify-between h-16" aria-label="Main navigation">
+      {/* Logo */}
+      <a href="/" class="flex items-center gap-2 font-bold text-lg text-[--text]">
+        <span class="text-2xl">🐱</span>
+        <span class="hidden sm:inline">CodingCat<span class="text-primary">.dev</span></span>
+      </a>
+
+      {/* Desktop Nav Links */}
+      <div class="hidden md:flex items-center gap-1">
+        {navLinks.map((link) => (
+          <a
+            href={link.path}
+            class:list={[
+              "px-3 py-2 rounded-lg text-sm font-medium transition-colors",
+              currentPath.startsWith(link.path)
+                ? "text-[--text] bg-[--surface-hover]"
+                : "text-[--text-secondary] hover:text-[--text] hover:bg-[--surface-hover]",
+            ]}
+          >
+            {link.title}
+          </a>
+        ))}
+      </div>
+
+      {/* Right Actions */}
+      <div class="flex items-center gap-1">
+        {/* Search Trigger */}
+        <button
+          class="p-2 rounded-lg text-[--text-secondary] hover:text-[--text] hover:bg-[--surface-hover] transition-colors"
+          data-search-trigger
+          aria-label="Search"
+        >
+          <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
+          </svg>
+        </button>
+
+        {/* Theme Toggle */}
+        <ThemeToggle />
+
+        {/* Mobile Hamburger */}
+        <button
+          class="md:hidden p-2 rounded-lg text-[--text-secondary] hover:text-[--text] hover:bg-[--surface-hover] transition-colors"
+          id="mobile-nav-trigger"
+          aria-label="Open menu"
+          aria-expanded="false"
+        >
+          <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
+          </svg>
+        </button>
+      </div>
+    </nav>
+  </Container>
+</header>
+
+{/* Mobile Nav Drawer */}
+<div id="mobile-nav" class="fixed inset-0 z-50 hidden" role="dialog" aria-modal="true">
+  {/* Backdrop */}
+  <div class="absolute inset-0 bg-black/60 backdrop-blur-sm" data-mobile-nav-close></div>
+
+  {/* Drawer */}
+  <div
+    class="absolute right-0 top-0 bottom-0 w-80 max-w-[85vw] bg-[--bg] border-l border-[--border] transform translate-x-full transition-transform duration-300"
+    id="mobile-nav-drawer"
+  >
+    <div class="flex items-center justify-between p-4 border-b border-[--border]">
+      <span class="font-bold text-[--text]">🐱 Menu</span>
+      <button
+        class="p-2 rounded-lg hover:bg-[--surface-hover] text-[--text-secondary]"
+        data-mobile-nav-close
+        aria-label="Close menu"
+      >
+        <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
+        </svg>
+      </button>
+    </div>
+
+    <nav class="p-4 space-y-1" aria-label="Mobile navigation">
+      {navLinks.map((link) => (
+        <a
+          href={link.path}
+          class:list={[
+            "block px-4 py-3 rounded-lg font-medium transition-colors",
+            currentPath.startsWith(link.path)
+              ? "text-[--text] bg-[--surface-hover]"
+              : "text-[--text] hover:bg-[--surface-hover]",
+          ]}
+        >
+          {link.title}
+        </a>
+      ))}
+      <a
+        href="/dashboard"
+        class="block px-4 py-3 rounded-lg text-[--text] font-medium hover:bg-[--surface-hover] transition-colors"
+      >
+        Dashboard
+      </a>
+    </nav>
+
+    {/* Social links at bottom */}
+    <div class="absolute bottom-0 left-0 right-0 p-4 border-t border-[--border]">
+      <div class="flex justify-center gap-4">
+        <a href="https://youtube.com/@codingcatdev" aria-label="YouTube" class="p-2 text-[--text-tertiary] hover:text-[--text]" target="_blank" rel="noopener">
+          <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor"><path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/></svg>
+        </a>
+        <a href="https://twitter.com/codingcatdev" aria-label="Twitter" class="p-2 text-[--text-tertiary] hover:text-[--text]" target="_blank" rel="noopener">
+          <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
+        </a>
+        <a href="https://github.com/codingcatdev" aria-label="GitHub" class="p-2 text-[--text-tertiary] hover:text-[--text]" target="_blank" rel="noopener">
+          <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script is:inline>
+(function() {
+  const trigger = document.getElementById('mobile-nav-trigger');
+  const nav = document.getElementById('mobile-nav');
+  const drawer = document.getElementById('mobile-nav-drawer');
+  const closeBtns = document.querySelectorAll('[data-mobile-nav-close]');
+
+  function open() {
+    nav?.classList.remove('hidden');
+    requestAnimationFrame(() => {
+      drawer?.classList.remove('translate-x-full');
+      trigger?.setAttribute('aria-expanded', 'true');
+    });
+    document.body.style.overflow = 'hidden';
+  }
+
+  function close() {
+    drawer?.classList.add('translate-x-full');
+    trigger?.setAttribute('aria-expanded', 'false');
+    document.body.style.overflow = '';
+    setTimeout(() => nav?.classList.add('hidden'), 300);
+  }
+
+  trigger?.addEventListener('click', open);
+  closeBtns.forEach(btn => btn.addEventListener('click', close));
+
+  // Close on Escape
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && !nav?.classList.contains('hidden')) close();
+  });
+})();
+</script>

--- a/apps/web/src/components/Pagination.astro
+++ b/apps/web/src/components/Pagination.astro
@@ -9,7 +9,7 @@ const { currentPage, totalPages, basePath } = Astro.props;
 
 const pages = Array.from({ length: totalPages }, (_, i) => i + 1);
 const showPages = pages.filter(
-  (p) => p === 1 || p === totalPages || Math.abs(p - currentPage) <= 2
+  (p) => p === 1 || p === totalPages || Math.abs(p - currentPage) <= 2,
 );
 ---
 
@@ -17,7 +17,7 @@ const showPages = pages.filter(
   {currentPage > 1 && (
     <a
       href={currentPage === 2 ? basePath : `${basePath}?page=${currentPage - 1}`}
-      class="px-4 py-2 border rounded-lg hover:bg-gray-50 transition-colors"
+      class="px-4 py-2 border border-[--border] rounded-lg text-[--text-secondary] hover:text-[--text] hover:bg-[--surface-hover] hover:border-[--border-hover] transition-colors"
     >
       &larr; Previous
     </a>
@@ -28,15 +28,16 @@ const showPages = pages.filter(
     const showEllipsis = prev && p - prev > 1;
     return (
       <>
-        {showEllipsis && <span class="px-2">&hellip;</span>}
+        {showEllipsis && <span class="px-2 text-[--text-tertiary]">&hellip;</span>}
         <a
           href={p === 1 ? basePath : `${basePath}?page=${p}`}
           class:list={[
             "px-4 py-2 rounded-lg transition-colors",
             p === currentPage
-              ? "bg-blue-600 text-white"
-              : "border hover:bg-gray-50",
+              ? "bg-primary text-white"
+              : "border border-[--border] text-[--text-secondary] hover:text-[--text] hover:bg-[--surface-hover] hover:border-[--border-hover]",
           ]}
+          aria-current={p === currentPage ? "page" : undefined}
         >
           {p}
         </a>
@@ -47,7 +48,7 @@ const showPages = pages.filter(
   {currentPage < totalPages && (
     <a
       href={`${basePath}?page=${currentPage + 1}`}
-      class="px-4 py-2 border rounded-lg hover:bg-gray-50 transition-colors"
+      class="px-4 py-2 border border-[--border] rounded-lg text-[--text-secondary] hover:text-[--text] hover:bg-[--surface-hover] hover:border-[--border-hover] transition-colors"
     >
       Next &rarr;
     </a>

--- a/apps/web/src/components/Tag.astro
+++ b/apps/web/src/components/Tag.astro
@@ -1,0 +1,23 @@
+---
+interface Props {
+  label: string;
+  href?: string;
+  active?: boolean;
+}
+
+const { label, href, active = false } = Astro.props;
+const resolvedHref = href ?? `/topic/${label.toLowerCase()}`;
+---
+
+<a
+  href={resolvedHref}
+  class:list={[
+    "inline-flex items-center px-3 py-1.5 rounded-full text-sm font-medium",
+    "transition-colors duration-150 border",
+    active
+      ? "bg-primary text-white border-primary"
+      : "bg-[--surface] text-[--text-secondary] border-[--border] hover:border-primary/50 hover:text-primary",
+  ]}
+>
+  {label}
+</a>

--- a/apps/web/src/components/ThemeScript.astro
+++ b/apps/web/src/components/ThemeScript.astro
@@ -1,0 +1,21 @@
+---
+/**
+ * Inline dark mode script — runs BEFORE CSS loads to prevent FOUC.
+ * Reads from localStorage, falls back to system preference, defaults to dark.
+ * Must be in <head> before any stylesheets.
+ */
+---
+
+<script is:inline>
+(function() {
+  const stored = localStorage.getItem('theme');
+  if (stored === 'light') {
+    document.documentElement.classList.add('light');
+  } else if (stored === 'dark') {
+    document.documentElement.classList.remove('light');
+  } else if (window.matchMedia('(prefers-color-scheme: light)').matches) {
+    document.documentElement.classList.add('light');
+  }
+  // Default: no class = dark mode (the default)
+})();
+</script>

--- a/apps/web/src/components/ThemeToggle.astro
+++ b/apps/web/src/components/ThemeToggle.astro
@@ -1,0 +1,46 @@
+---
+/**
+ * Theme toggle button — switches between dark (default) and light mode.
+ * Uses localStorage to persist preference across sessions.
+ * Renders as a React island (client:load) for interactivity.
+ */
+---
+
+<button
+  id="theme-toggle"
+  class="p-2 rounded-lg text-[--text-secondary] hover:text-[--text] hover:bg-[--surface-hover] transition-colors"
+  aria-label="Toggle theme"
+>
+  {/* Sun icon — shown in dark mode (click to go light) */}
+  <svg class="w-5 h-5 hidden" id="theme-icon-sun" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z" />
+  </svg>
+  {/* Moon icon — shown in light mode (click to go dark) */}
+  <svg class="w-5 h-5" id="theme-icon-moon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.72 9.72 0 0 1 18 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 0 0 3 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 0 0 9.002-5.998Z" />
+  </svg>
+</button>
+
+<script is:inline>
+(function() {
+  const btn = document.getElementById('theme-toggle');
+  const sunIcon = document.getElementById('theme-icon-sun');
+  const moonIcon = document.getElementById('theme-icon-moon');
+
+  function updateIcons() {
+    const isLight = document.documentElement.classList.contains('light');
+    if (sunIcon && moonIcon) {
+      sunIcon.classList.toggle('hidden', isLight);
+      moonIcon.classList.toggle('hidden', !isLight);
+    }
+  }
+
+  updateIcons();
+
+  btn?.addEventListener('click', () => {
+    const isLight = document.documentElement.classList.toggle('light');
+    localStorage.setItem('theme', isLight ? 'light' : 'dark');
+    updateIcons();
+  });
+})();
+</script>

--- a/apps/web/src/layouts/BaseLayout.astro
+++ b/apps/web/src/layouts/BaseLayout.astro
@@ -1,5 +1,8 @@
 ---
 import "../styles/global.css";
+import ThemeScript from "../components/ThemeScript.astro";
+import Header from "../components/Header.astro";
+import Footer from "../components/Footer.astro";
 import { VisualEditing } from "@sanity/astro/visual-editing";
 
 interface Props {
@@ -23,30 +26,28 @@ const visualEditingEnabled =
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="alternate" type="application/rss+xml" title="CodingCat.dev Blog" href="/rss.xml" />
     <link rel="alternate" type="application/rss+xml" title="CodingCat.dev Podcast" href="/podcast/rss.xml" />
+
+    {/* Dark mode script — MUST be before CSS to prevent FOUC */}
+    <ThemeScript />
+
+    {/* Fonts — Inter (body) + JetBrains Mono (code) */}
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+
     <title>{title}</title>
   </head>
-  <body class="min-h-screen flex flex-col">
-    <header class="border-b">
-      <nav class="container mx-auto px-4 py-4 flex items-center justify-between">
-        <a href="/" class="text-xl font-bold">🐱 CodingCat.dev</a>
-        <div class="flex items-center gap-6">
-          <a href="/blog" class="hover:text-blue-600 transition-colors">Blog</a>
-          <a href="/podcasts" class="hover:text-blue-600 transition-colors">Podcasts</a>
-          <a href="/authors" class="hover:text-blue-600 transition-colors">Authors</a>
-          <a href="/dashboard" class="hover:text-blue-600 transition-colors">Dashboard</a>
-        </div>
-      </nav>
-    </header>
+  <body class="min-h-screen flex flex-col bg-[--bg] text-[--text]">
+    <Header />
 
     <div class="flex-1">
       <slot />
     </div>
 
-    <footer class="border-t mt-16">
-      <div class="container mx-auto px-4 py-8 text-center text-gray-500">
-        <p>&copy; {new Date().getFullYear()} CodingCat.dev. All rights reserved.</p>
-      </div>
-    </footer>
+    <Footer />
 
     <VisualEditing enabled={visualEditingEnabled} />
   </body>

--- a/apps/web/src/styles/global.css
+++ b/apps/web/src/styles/global.css
@@ -1,1 +1,289 @@
 @import "tailwindcss";
+
+/* ═══════════════════════════════════════════════════════════════
+   CodingCat.dev Design System — Tailwind CSS 4 Theme Tokens
+   Dark-first brand: black bg, white text, violet accent
+   ═══════════════════════════════════════════════════════════════ */
+
+@theme {
+  /* ─── Brand Core ─── */
+  --color-primary: #7c3aed;
+  --color-primary-hover: #6d28d9;
+  --color-primary-light: #8b5cf6;
+  --color-primary-muted: #7c3aed33;
+
+  --color-secondary: #06b6d4;
+  --color-secondary-hover: #0891b2;
+
+  --color-accent: #f59e0b;
+  --color-accent-hover: #d97706;
+
+  --color-destructive: #ef4444;
+  --color-destructive-hover: #dc2626;
+
+  /* ─── Content Type Colors ─── */
+  --color-type-blog: #3b82f6;
+  --color-type-podcast: #f59e0b;
+  --color-type-course: #10b981;
+  --color-type-video: #ef4444;
+  --color-type-short: #ec4899;
+
+  /* ─── Code Block Colors ─── */
+  --color-code-bg: #0d1117;
+  --color-code-border: #30363d;
+  --color-code-text: #e6edf3;
+
+  /* ─── Typography ─── */
+  --font-sans: "Inter", system-ui, -apple-system, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, monospace;
+
+  /* ─── Border Radius ─── */
+  --radius-sm: 0.25rem;
+  --radius-md: 0.5rem;
+  --radius-lg: 0.75rem;
+  --radius-full: 9999px;
+
+  /* ─── Transitions ─── */
+  --transition-fast: 150ms cubic-bezier(0.4, 0, 0.2, 1);
+  --transition-base: 200ms cubic-bezier(0.4, 0, 0.2, 1);
+  --transition-slow: 300ms cubic-bezier(0.4, 0, 0.2, 1);
+
+  /* ─── Shadows ─── */
+  --shadow-glow: 0 0 20px rgba(124, 58, 237, 0.15);
+  --shadow-glow-lg: 0 0 40px rgba(124, 58, 237, 0.25);
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   Theme Variables — Dark mode is DEFAULT
+   Switch to light via <html class="light">
+   ═══════════════════════════════════════════════════════════════ */
+
+:root {
+  --bg: #000000;
+  --bg-secondary: #0a0a0a;
+  --bg-tertiary: #141414;
+  --surface: #1a1a1a;
+  --surface-hover: #222222;
+  --surface-raised: #262626;
+
+  --border: #262626;
+  --border-hover: #404040;
+  --border-focus: #7c3aed;
+
+  --text: #ffffff;
+  --text-secondary: #a3a3a3;
+  --text-tertiary: #737373;
+  --text-inverse: #000000;
+
+  --muted: #262626;
+  --muted-fg: #a3a3a3;
+
+  color-scheme: dark;
+}
+
+html.light {
+  --bg: #ffffff;
+  --bg-secondary: #fafafa;
+  --bg-tertiary: #f5f5f5;
+  --surface: #ffffff;
+  --surface-hover: #f5f5f5;
+  --surface-raised: #ffffff;
+
+  --border: #e5e5e5;
+  --border-hover: #d4d4d4;
+  --border-focus: #7c3aed;
+
+  --text: #0a0a0a;
+  --text-secondary: #525252;
+  --text-tertiary: #a3a3a3;
+  --text-inverse: #ffffff;
+
+  --muted: #f5f5f5;
+  --muted-fg: #737373;
+
+  color-scheme: light;
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   Base Styles
+   ═══════════════════════════════════════════════════════════════ */
+
+html {
+  font-family: var(--font-sans);
+  background-color: var(--bg);
+  color: var(--text);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  min-height: 100vh;
+  background-color: var(--bg);
+}
+
+/* Focus ring — consistent across all interactive elements */
+:focus-visible {
+  outline: 2px solid var(--border-focus);
+  outline-offset: 2px;
+}
+
+/* Selection color */
+::selection {
+  background-color: var(--color-primary-muted);
+  color: var(--text);
+}
+
+/* Scrollbar styling (dark mode friendly) */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: var(--bg-secondary);
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--border-hover);
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--text-tertiary);
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   Prose / Article Styles
+   ═══════════════════════════════════════════════════════════════ */
+
+.prose {
+  color: var(--text-secondary);
+  line-height: 1.7;
+  font-size: 1.125rem;
+}
+
+.prose h1,
+.prose h2,
+.prose h3,
+.prose h4,
+.prose h5,
+.prose h6 {
+  color: var(--text);
+  font-weight: 700;
+  line-height: 1.3;
+  margin-top: 2em;
+  margin-bottom: 0.75em;
+}
+
+.prose h1 { font-size: 2.25rem; }
+.prose h2 { font-size: 1.875rem; border-bottom: 1px solid var(--border); padding-bottom: 0.5rem; }
+.prose h3 { font-size: 1.5rem; }
+.prose h4 { font-size: 1.25rem; }
+
+.prose p {
+  margin-bottom: 1.25em;
+}
+
+.prose a {
+  color: var(--color-primary-light);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  transition: color var(--transition-fast);
+}
+
+.prose a:hover {
+  color: var(--color-primary);
+}
+
+.prose code {
+  font-family: var(--font-mono);
+  font-size: 0.875em;
+  background-color: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0.125em 0.375em;
+}
+
+.prose pre {
+  margin: 1.5em 0;
+}
+
+.prose pre code {
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: 0.875rem;
+}
+
+.prose img {
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  margin: 1.5em 0;
+}
+
+.prose blockquote {
+  border-left: 4px solid var(--color-primary);
+  padding-left: 1.5rem;
+  margin: 1.5em 0;
+  font-style: italic;
+  color: var(--text);
+}
+
+.prose ul,
+.prose ol {
+  padding-left: 1.5em;
+  margin-bottom: 1.25em;
+}
+
+.prose li {
+  margin-bottom: 0.5em;
+}
+
+.prose ul li::marker {
+  color: var(--color-primary);
+}
+
+.prose ol li::marker {
+  color: var(--text-tertiary);
+  font-weight: 600;
+}
+
+.prose hr {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: 2em 0;
+}
+
+.prose table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5em 0;
+}
+
+.prose th,
+.prose td {
+  border: 1px solid var(--border);
+  padding: 0.75rem 1rem;
+  text-align: left;
+}
+
+.prose th {
+  background-color: var(--surface);
+  color: var(--text);
+  font-weight: 600;
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   Reduced Motion
+   ═══════════════════════════════════════════════════════════════ */
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
# Design System Foundation — Track B

Implements the design system from `/specs/design-system.md`. This is the foundation that all page redesigns (Track C) will build on.

## What's Included

### Tailwind CSS 4 `@theme` Tokens (`global.css`)
- **Brand colors**: violet primary (#7c3aed), cyan secondary, amber accent
- **Content type colors**: blue (blog), amber (podcast), emerald (course), red (video), pink (short)
- **Dark mode (default)**: pure black bg, white text, subtle borders
- **Light mode**: white bg, dark text — toggled via `html.light` class
- **Typography**: Inter (body) + JetBrains Mono (code) via Google Fonts with `font-display: swap`
- **Custom shadows**: `shadow-glow`, `shadow-glow-lg` for featured elements
- **Prose styles**: article content with heading hierarchy, code blocks, blockquotes, tables
- **Reduced motion**: respects `prefers-reduced-motion`

### Dark Mode
- `ThemeScript.astro` — inline `<script>` in `<head>` **before CSS** (prevents FOUC)
- `ThemeToggle.astro` — sun/moon toggle, persists to `localStorage`
- Uses `class` strategy (not Tailwind's `dark:` variant) — dark is default, light is opt-in

### Base Components (10 new)

| Component | Description |
|-----------|-------------|
| `Button.astro` | 4 variants (primary/secondary/ghost/destructive), 3 sizes, polymorphic (a or button) |
| `Badge.astro` | Content type badges using CSS custom property colors (not hardcoded hex) |
| `Avatar.astro` | Image with initials fallback, 5 sizes (xs–xl) |
| `Tag.astro` | Topic filter pills with active state |
| `Container.astro` | 4 width presets (narrow/default/wide/full) |
| `ContentCard.astro` | Standard grid card — redesigned with design system tokens |
| `ContentCardFeatured.astro` | Hero full-width card with excerpt + guest support |
| `ContentCardCompact.astro` | Compact horizontal list card for sidebars/rails |
| `Header.astro` | Sticky header: logo, nav, search trigger, theme toggle, mobile drawer |
| `Footer.astro` | 4-column footer: brand + newsletter, content links, social, legal |

### Updated Components
- `Pagination.astro` — updated from hardcoded colors to design system tokens
- `BaseLayout.astro` — uses Header/Footer, Google Fonts, ThemeScript, dark mode cookie check

### What's NOT in this PR
- No page layout changes — pages still use the same structure, just with new header/footer/tokens
- No Sanity schema dependencies — all components work with existing data
- No OG image generation (Track D)
- No new page designs (Track C)

## Design Decisions

| Decision | Rationale |
|----------|-----------|
| `class` strategy over `dark:` | Dark is default — we add `light` class, not `dark` |
| Inline theme script in `<head>` | Prevents flash of wrong theme on page load |
| CSS custom properties for theme vars | Enables runtime theme switching without rebuilding |
| Content type colors as `@theme` tokens | Badge, cards, and future components all reference the same source |
| Google Fonts over self-hosted | Simpler for now, can optimize later with `@fontsource` |

## Build

20.38s ✅ (15 files changed: 10 new, 5 modified)

## For @uidesigner Review

Please verify against the spec:
- [ ] Color tokens match Section 1.1
- [ ] Typography tokens match Section 1.2
- [ ] Badge colors use CSS custom properties (not hardcoded)
- [ ] Dark mode default, light mode toggle
- [ ] Header matches Section 3.5 wireframe
- [ ] Footer matches Section 3.6 wireframe
- [ ] ContentCard variants match Section 2.1