### PR TITLE
feat: schema redesign — socialPreview, podcastSeries, category, short + podcast/guest/post/page/sponsor updates

### DIFF
--- a/apps/sanity/sanity.config.ts
+++ b/apps/sanity/sanity.config.ts
@@ -42,9 +42,12 @@ import videoAnalytics from "./schemas/documents/videoAnalytics";
 import sponsorLead from "./schemas/documents/sponsorLead";
 import sponsorPool from "./schemas/documents/sponsorPool";
 import tableSchema, { rowType } from "./schemas/custom/table";
+import podcastSeries from "./schemas/documents/podcastSeries";
+import category from "./schemas/documents/category";
+import short from "./schemas/documents/short";
 
 // Sanity Studio env vars (SANITY_STUDIO_ prefix is auto-exposed by Sanity CLI)
-const projectId = process.env.SANITY_STUDIO_PROJECT_ID || "hfh83o0w";
+const projectId = process.env.SANITY_STUDIO_PROJECT_ID || "kc0imnra";
 const dataset = process.env.SANITY_STUDIO_DATASET || "production";
 const apiVersion = process.env.SANITY_STUDIO_API_VERSION || "2025-09-30";
 const studioUrl = "/";
@@ -163,6 +166,10 @@ export default defineConfig({
       videoAnalytics,
       sponsorLead,
       sponsorPool,
+      // New document types
+      podcastSeries,
+      category,
+      short,
     ],
   },
   document: {

--- a/apps/sanity/sanity.config.ts
+++ b/apps/sanity/sanity.config.ts
@@ -47,7 +47,7 @@ import category from "./schemas/documents/category";
 import short from "./schemas/documents/short";
 
 // Sanity Studio env vars (SANITY_STUDIO_ prefix is auto-exposed by Sanity CLI)
-const projectId = process.env.SANITY_STUDIO_PROJECT_ID || "kc0imnra";
+const projectId = process.env.SANITY_STUDIO_PROJECT_ID || "hfh83o0w";
 const dataset = process.env.SANITY_STUDIO_DATASET || "production";
 const apiVersion = process.env.SANITY_STUDIO_API_VERSION || "2025-09-30";
 const studioUrl = "/";

--- a/apps/sanity/schemas/documents/category.ts
+++ b/apps/sanity/schemas/documents/category.ts
@@ -1,0 +1,45 @@
+import { defineField, defineType } from "sanity";
+import { TagIcon } from "@sanity/icons";
+
+export default defineType({
+	name: "category",
+	title: "Category",
+	type: "document",
+	icon: TagIcon,
+	fields: [
+		defineField({
+			name: "title",
+			title: "Title",
+			type: "string",
+			validation: (rule) => rule.required(),
+		}),
+		defineField({
+			name: "slug",
+			title: "Slug",
+			type: "slug",
+			options: {
+				source: "title",
+				maxLength: 96,
+				isUnique: (value, context) =>
+					context.defaultIsUnique(value, context),
+			},
+			validation: (rule) => rule.required(),
+		}),
+		defineField({
+			name: "description",
+			title: "Description",
+			type: "text",
+		}),
+		defineField({
+			name: "color",
+			title: "Color",
+			type: "string",
+			description: "Hex color for category badge (e.g. #7c3aed)",
+		}),
+	],
+	preview: {
+		select: {
+			title: "title",
+		},
+	},
+});

--- a/apps/sanity/schemas/documents/guest.ts
+++ b/apps/sanity/schemas/documents/guest.ts
@@ -1,5 +1,5 @@
 import { UserIcon } from "@sanity/icons";
-import { defineType } from "sanity";
+import { defineField, defineType } from "sanity";
 
 import userType from "../partials/user";
 
@@ -9,4 +9,19 @@ export default defineType({
 	title: "Guest",
 	icon: UserIcon,
 	type: "document",
+	fields: [
+		...userType.fields,
+		defineField({
+			name: "company",
+			title: "Company",
+			type: "string",
+			description: "Company or organization",
+		}),
+		defineField({
+			name: "role",
+			title: "Role",
+			type: "string",
+			description: "Job title or role",
+		}),
+	],
 });

--- a/apps/sanity/schemas/documents/page.ts
+++ b/apps/sanity/schemas/documents/page.ts
@@ -2,6 +2,10 @@ import { DocumentTextIcon } from "@sanity/icons";
 import { defineType } from "sanity";
 
 import contentType from "../partials/content";
+import {
+	socialPreviewFields,
+	socialPreviewGroup,
+} from "../partials/socialPreview";
 
 export default defineType({
 	...contentType,
@@ -9,4 +13,6 @@ export default defineType({
 	title: "Page",
 	icon: DocumentTextIcon,
 	type: "document",
+	groups: [...(contentType.groups || []), socialPreviewGroup],
+	fields: [...contentType.fields, ...socialPreviewFields],
 });

--- a/apps/sanity/schemas/documents/podcast.ts
+++ b/apps/sanity/schemas/documents/podcast.ts
@@ -3,9 +3,16 @@ import { format, parseISO } from "date-fns";
 import { defineField, defineType } from "sanity";
 
 import contentType from "../partials/content";
+import {
+	socialPreviewFields,
+	socialPreviewGroup,
+} from "../partials/socialPreview";
 import podcastType from "./podcastType";
 import guestType from "./guest";
 import authorType from "./author";
+import podcastSeriesType from "./podcastSeries";
+import shortType from "./short";
+import postType from "./post";
 
 export default defineType({
 	...contentType,
@@ -15,6 +22,7 @@ export default defineType({
 	type: "document",
 	groups: [
 		...(contentType.groups || []),
+		socialPreviewGroup,
 		{
 			name: "podcast",
 			title: "Podcast Details",
@@ -22,6 +30,8 @@ export default defineType({
 	],
 	fields: [
 		...contentType.fields,
+		...socialPreviewFields,
+		// --- Existing podcast-specific fields ---
 		defineField({
 			name: "podcastType",
 			title: "Podcast Type",
@@ -124,6 +134,153 @@ export default defineType({
 			title: "Spotify",
 			type: "podcastRssEpisode",
 			// validation: (rule) => [rule.required()],
+		}),
+		// --- New fields ---
+		defineField({
+			name: "thumbnail",
+			title: "Thumbnail",
+			type: "image",
+			options: {
+				hotspot: true,
+			},
+			group: "podcast",
+			description:
+				"YouTube-optimized thumbnail (1280×720). Falls back to coverImage.",
+		}),
+		defineField({
+			name: "duration",
+			title: "Duration",
+			type: "number",
+			group: "podcast",
+			description: "Episode duration in seconds",
+		}),
+		defineField({
+			name: "chapters",
+			title: "Chapters",
+			type: "array",
+			group: "podcast",
+			of: [
+				{
+					type: "object",
+					fields: [
+						defineField({
+							name: "title",
+							title: "Title",
+							type: "string",
+							validation: (rule) => rule.required(),
+						}),
+						defineField({
+							name: "timestamp",
+							title: "Timestamp",
+							type: "string",
+							validation: (rule) => rule.required(),
+							description: "Display format e.g. 02:34",
+						}),
+						defineField({
+							name: "seconds",
+							title: "Seconds",
+							type: "number",
+							validation: (rule) => rule.required(),
+							description: "Timestamp in seconds for seeking",
+						}),
+					],
+					preview: {
+						select: {
+							title: "title",
+							subtitle: "timestamp",
+						},
+					},
+				},
+			],
+		}),
+		defineField({
+			name: "series",
+			title: "Series",
+			type: "reference",
+			to: [{ type: podcastSeriesType.name }],
+			group: "podcast",
+		}),
+		defineField({
+			name: "seriesOrder",
+			title: "Series Order",
+			type: "number",
+			group: "podcast",
+			description: "Position within the series",
+		}),
+		defineField({
+			name: "listenLinks",
+			title: "Listen Links",
+			type: "object",
+			group: "podcast",
+			description: "Multi-platform listen links",
+			fields: [
+				defineField({
+					name: "youtube",
+					title: "YouTube",
+					type: "string",
+				}),
+				defineField({
+					name: "spotify",
+					title: "Spotify",
+					type: "string",
+				}),
+				defineField({
+					name: "apple",
+					title: "Apple Podcasts",
+					type: "string",
+				}),
+				defineField({
+					name: "overcast",
+					title: "Overcast",
+					type: "string",
+				}),
+				defineField({
+					name: "pocketCasts",
+					title: "Pocket Casts",
+					type: "string",
+				}),
+				defineField({
+					name: "rss",
+					title: "RSS",
+					type: "string",
+				}),
+			],
+		}),
+		defineField({
+			name: "transcript",
+			title: "Transcript",
+			type: "text",
+			group: "podcast",
+			description: "Full episode transcript",
+		}),
+		defineField({
+			name: "contentType",
+			title: "Content Type",
+			type: "string",
+			group: "podcast",
+			description: "Episode format",
+			options: {
+				list: ["interview", "solo", "tutorial", "news", "review"],
+			},
+		}),
+		defineField({
+			name: "relatedShorts",
+			title: "Related Shorts",
+			type: "array",
+			group: "podcast",
+			of: [
+				{
+					type: "reference",
+					to: [{ type: shortType.name }],
+				},
+			],
+		}),
+		defineField({
+			name: "relatedBlogPost",
+			title: "Related Blog Post",
+			type: "reference",
+			group: "podcast",
+			to: [{ type: postType.name }],
 		}),
 	],
 	orderings: [

--- a/apps/sanity/schemas/documents/podcastSeries.ts
+++ b/apps/sanity/schemas/documents/podcastSeries.ts
@@ -1,0 +1,61 @@
+import { defineField, defineType } from "sanity";
+import { FaLayerGroup } from "react-icons/fa";
+
+export default defineType({
+	name: "podcastSeries",
+	title: "Podcast Series",
+	type: "document",
+	icon: FaLayerGroup,
+	fields: [
+		defineField({
+			name: "title",
+			title: "Title",
+			type: "string",
+			validation: (rule) => rule.required(),
+		}),
+		defineField({
+			name: "slug",
+			title: "Slug",
+			type: "slug",
+			options: {
+				source: "title",
+				maxLength: 96,
+				isUnique: (value, context) =>
+					context.defaultIsUnique(value, context),
+			},
+			validation: (rule) => rule.required(),
+		}),
+		defineField({
+			name: "description",
+			title: "Description",
+			type: "text",
+		}),
+		defineField({
+			name: "coverImage",
+			title: "Cover Image",
+			type: "image",
+			options: {
+				hotspot: true,
+			},
+		}),
+		defineField({
+			name: "youtubePlaylistId",
+			title: "YouTube Playlist ID",
+			type: "string",
+			description: "YouTube playlist ID for this series",
+		}),
+		defineField({
+			name: "isActive",
+			title: "Is Active",
+			type: "boolean",
+			initialValue: true,
+			description: "Is this series still producing new episodes?",
+		}),
+	],
+	preview: {
+		select: {
+			title: "title",
+			subtitle: "description",
+		},
+	},
+});

--- a/apps/sanity/schemas/documents/post.ts
+++ b/apps/sanity/schemas/documents/post.ts
@@ -1,7 +1,12 @@
 import { HiOutlinePencilAlt } from "react-icons/hi";
-import { defineType } from "sanity";
+import { defineField, defineType } from "sanity";
 
 import contentType from "../partials/content";
+import {
+	socialPreviewFields,
+	socialPreviewGroup,
+} from "../partials/socialPreview";
+import categoryType from "./category";
 
 export default defineType({
 	...contentType,
@@ -9,4 +14,20 @@ export default defineType({
 	title: "Post",
 	icon: HiOutlinePencilAlt,
 	type: "document",
+	groups: [...(contentType.groups || []), socialPreviewGroup],
+	fields: [
+		...contentType.fields,
+		...socialPreviewFields,
+		defineField({
+			name: "categories",
+			title: "Categories",
+			type: "array",
+			of: [
+				{
+					type: "reference",
+					to: [{ type: categoryType.name }],
+				},
+			],
+		}),
+	],
 });

--- a/apps/sanity/schemas/documents/short.ts
+++ b/apps/sanity/schemas/documents/short.ts
@@ -1,0 +1,81 @@
+import { defineField, defineType } from "sanity";
+import { PlayIcon } from "@sanity/icons";
+
+import categoryType from "./category";
+
+export default defineType({
+	name: "short",
+	title: "Short",
+	type: "document",
+	icon: PlayIcon,
+	fields: [
+		defineField({
+			name: "title",
+			title: "Title",
+			type: "string",
+			validation: (rule) => rule.required(),
+		}),
+		defineField({
+			name: "slug",
+			title: "Slug",
+			type: "slug",
+			options: {
+				source: "title",
+				maxLength: 96,
+				isUnique: (value, context) =>
+					context.defaultIsUnique(value, context),
+			},
+			validation: (rule) => rule.required(),
+		}),
+		defineField({
+			name: "youtube",
+			title: "YouTube",
+			type: "string",
+			description: "YouTube Shorts video ID or URL",
+		}),
+		defineField({
+			name: "thumbnail",
+			title: "Thumbnail",
+			type: "image",
+			options: {
+				hotspot: true,
+			},
+			description: "Vertical thumbnail (9:16)",
+		}),
+		defineField({
+			name: "parentEpisode",
+			title: "Parent Episode",
+			type: "reference",
+			to: [{ type: "podcast" }],
+			description: "Long-form episode this Short was clipped from",
+		}),
+		defineField({
+			name: "publishedAt",
+			title: "Published At",
+			type: "datetime",
+		}),
+		defineField({
+			name: "duration",
+			title: "Duration",
+			type: "number",
+			description: "Duration in seconds",
+		}),
+		defineField({
+			name: "categories",
+			title: "Categories",
+			type: "array",
+			of: [
+				{
+					type: "reference",
+					to: [{ type: categoryType.name }],
+				},
+			],
+		}),
+	],
+	preview: {
+		select: {
+			title: "title",
+			subtitle: "publishedAt",
+		},
+	},
+});

--- a/apps/sanity/schemas/documents/sponsor.ts
+++ b/apps/sanity/schemas/documents/sponsor.ts
@@ -3,14 +3,20 @@ import { format, parseISO } from "date-fns";
 import { defineField, defineType } from "sanity";
 
 import baseType from "../partials/base";
+import {
+	socialPreviewFields,
+	socialPreviewGroup,
+} from "../partials/socialPreview";
 
 export default defineType({
 	name: "sponsor",
 	title: "Sponsor",
 	icon: PiCurrencyDollarSimpleFill,
 	type: "document",
+	groups: [socialPreviewGroup],
 	fields: [
 		...baseType.fields,
+		...socialPreviewFields,
 		defineField({
 			title: "Link",
 			name: "url",

--- a/apps/sanity/schemas/partials/socialPreview.ts
+++ b/apps/sanity/schemas/partials/socialPreview.ts
@@ -1,0 +1,55 @@
+import { defineField } from "sanity";
+
+export const socialPreviewGroup = {
+	name: "socialPreview",
+	title: "Social Preview",
+};
+
+export const socialPreviewFields = [
+	defineField({
+		name: "ogTitle",
+		title: "Social Title",
+		type: "string",
+		group: "socialPreview",
+		description: "Override title for social sharing (max 60 chars)",
+		validation: (rule) => rule.max(60),
+	}),
+	defineField({
+		name: "ogDescription",
+		title: "Social Description",
+		type: "text",
+		group: "socialPreview",
+		rows: 3,
+		description: "Override description for social sharing (max 155 chars)",
+		validation: (rule) => rule.max(155),
+	}),
+	defineField({
+		name: "ogImage",
+		title: "Social Image",
+		type: "image",
+		group: "socialPreview",
+		options: {
+			hotspot: true,
+		},
+		description:
+			"Custom social preview image (1200×630). Auto-generated if empty.",
+	}),
+	defineField({
+		name: "twitterCardType",
+		title: "Twitter Card Type",
+		type: "string",
+		group: "socialPreview",
+		options: {
+			list: ["summary_large_image", "summary"],
+		},
+		initialValue: "summary_large_image",
+	}),
+	defineField({
+		name: "noIndex",
+		title: "No Index",
+		type: "boolean",
+		group: "socialPreview",
+		initialValue: false,
+		description: "Hide this page from search engines",
+	}),
+];


### PR DESCRIPTION
## Track A: Sanity Schema Updates for Website Redesign

### New Partial
- **`socialPreview`** (`schemas/partials/socialPreview.ts`) — 5 optional fields applied to all content types:
  - `ogTitle` (string, max 60 chars) — social title override
  - `ogDescription` (text, max 155 chars) — social description override
  - `ogImage` (image, hotspot: true) — custom OG image (1200×630)
  - `twitterCardType` (enum: summary_large_image | summary)
  - `noIndex` (boolean) — hide from search engines
  - All fields fall back to `title`, `excerpt`, `coverImage` when empty

### New Document Types
- **`podcastSeries`** — series grouping for podcast episodes (title, slug, description, coverImage, youtubePlaylistId, isActive)
- **`category`** — content taxonomy with color badges (title, slug, description, color)
- **`short`** — standalone YouTube Shorts (title, slug, youtube, thumbnail, parentEpisode→podcast, publishedAt, duration, categories)

### Updated Documents
- **`podcast`** — 11 new fields: thumbnail, duration, chapters (title+timestamp+seconds), series→podcastSeries, seriesOrder, listenLinks (youtube/spotify/apple/overcast/pocketCasts/rss), transcript, contentType enum (interview/solo/tutorial/news/review), relatedShorts, relatedBlogPost, + socialPreview partial
- **`guest`** — +company, +role (socials already exist via user partial)
- **`post`** — +categories (refs to category), +socialPreview partial
- **`page`** — +socialPreview partial
- **`sponsor`** — +socialPreview partial

### NOT included (deferred per @pm)
- course, lesson document types
- page builder blocks (hero, featureGrid, etc.)
- author changes (socials already exist)

### Registration
All 3 new types registered in `sanity.config.ts`.

### Specs
- Design system: `/specs/design-system.md` Section 7
- Podcast requirements: `/specs/podcast-video-requirements.md` Section 3
- Social preview: `/specs/social-preview-requirements.md` Section 5
- Gap analysis: `/specs/schema-gap-analysis.md`