### PR TITLE
feat: page redesigns — design system, schema fields, SocialMeta, OG images (Track C)

### DIFF
--- a/apps/web/src/components/PersonDetail.astro
+++ b/apps/web/src/components/PersonDetail.astro
@@ -2,6 +2,8 @@
 import { PortableText } from "astro-portabletext";
 import { urlForImage } from "@/utils/sanity";
 import ContentCard from "./ContentCard.astro";
+import Avatar from "./Avatar.astro";
+import Badge from "./Badge.astro";
 
 interface Props {
   person: any;
@@ -21,7 +23,7 @@ function getHostname(url: string): string {
 ---
 
 <div class="flex flex-col md:flex-row gap-8 mb-12">
-  {coverUrl && (
+  {coverUrl ? (
     <img
       src={coverUrl}
       alt={person.title}
@@ -29,26 +31,37 @@ function getHostname(url: string): string {
       height={400}
       class="w-48 h-48 rounded-full object-cover flex-shrink-0"
     />
+  ) : (
+    <Avatar name={person.title} size="xl" />
   )}
   <div>
-    <h1 class="text-4xl font-bold mb-4">{person.title}</h1>
-    {person.excerpt && (
-      <p class="text-gray-600 text-lg mb-4">{person.excerpt}</p>
+    <h1 class="text-4xl font-bold text-[--text] mb-2">{person.title}</h1>
+
+    {/* Company & Role for guests */}
+    {(person.company || person.role) && (
+      <p class="text-lg text-[--text-secondary] mb-2">
+        {[person.role, person.company].filter(Boolean).join(" at ")}
+      </p>
     )}
+
+    {person.excerpt && (
+      <p class="text-[--text-secondary] text-lg mb-4">{person.excerpt}</p>
+    )}
+
     {person.socials && (
       <div class="flex flex-wrap gap-3">
         {person.socials.twitter && (
-          <a href={`https://twitter.com/${person.socials.twitter}`} target="_blank" rel="noopener noreferrer" class="text-blue-500 hover:underline">
+          <a href={`https://twitter.com/${person.socials.twitter}`} target="_blank" rel="noopener noreferrer" class="text-[--text-secondary] hover:text-primary transition-colors">
             Twitter
           </a>
         )}
         {person.socials.github && (
-          <a href={`https://github.com/${person.socials.github}`} target="_blank" rel="noopener noreferrer" class="text-gray-700 hover:underline">
+          <a href={`https://github.com/${person.socials.github}`} target="_blank" rel="noopener noreferrer" class="text-[--text-secondary] hover:text-primary transition-colors">
             GitHub
           </a>
         )}
         {person.socials.linkedin && (
-          <a href={person.socials.linkedin} target="_blank" rel="noopener noreferrer" class="text-blue-700 hover:underline">
+          <a href={person.socials.linkedin} target="_blank" rel="noopener noreferrer" class="text-[--text-secondary] hover:text-primary transition-colors">
             LinkedIn
           </a>
         )}
@@ -57,7 +70,7 @@ function getHostname(url: string): string {
     {person.websites && person.websites.length > 0 && (
       <div class="flex flex-wrap gap-3 mt-2">
         {person.websites.map((site: string) => (
-          <a href={site} target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:underline text-sm">
+          <a href={site} target="_blank" rel="noopener noreferrer" class="text-sm text-[--text-secondary] hover:text-primary transition-colors">
             {getHostname(site)}
           </a>
         ))}
@@ -67,7 +80,16 @@ function getHostname(url: string): string {
 </div>
 
 {person.content && (
-  <div class="prose prose-lg max-w-none mb-12">
+  <div class="prose prose-lg prose-invert max-w-none mb-12
+    prose-headings:text-[--text] prose-headings:font-bold
+    prose-p:text-[--text-secondary]
+    prose-a:text-primary prose-a:no-underline hover:prose-a:underline
+    prose-strong:text-[--text]
+    prose-code:text-primary prose-code:bg-[--surface] prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded
+    prose-pre:bg-[--surface] prose-pre:border prose-pre:border-[--border] prose-pre:rounded-xl
+    prose-blockquote:border-primary prose-blockquote:text-[--text-secondary]
+    prose-li:text-[--text-secondary]
+  ">
     <PortableText value={person.content} />
   </div>
 )}
@@ -76,15 +98,20 @@ function getHostname(url: string): string {
   <>
     {person.related.podcast && person.related.podcast.length > 0 && (
       <section class="mb-12">
-        <h2 class="text-2xl font-bold mb-6">Related Podcasts</h2>
-        <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
+        <div class="flex items-center gap-3 mb-6">
+          <Badge type="podcast" />
+          <h2 class="text-2xl font-bold text-[--text]">Related Podcasts</h2>
+        </div>
+        <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
           {person.related.podcast.map((p: any) => (
             <ContentCard
               title={p.title}
-              slug={`/podcast/${p.slug}`}
-              coverImage={p.coverImage}
-              excerpt={p.excerpt}
-              date={p.date}
+              url={`/podcast/${p.slug}`}
+              type="podcast"
+              thumbnail={p.coverImage}
+              authorName={p.authorName}
+              authorImage={p.authorImage}
+              metadata={p.date ? new Date(p.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" }) : undefined}
             />
           ))}
         </div>
@@ -93,15 +120,20 @@ function getHostname(url: string): string {
 
     {person.related.post && person.related.post.length > 0 && (
       <section class="mb-12">
-        <h2 class="text-2xl font-bold mb-6">Related Posts</h2>
-        <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
+        <div class="flex items-center gap-3 mb-6">
+          <Badge type="blog" />
+          <h2 class="text-2xl font-bold text-[--text]">Related Posts</h2>
+        </div>
+        <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
           {person.related.post.map((p: any) => (
             <ContentCard
               title={p.title}
-              slug={`/post/${p.slug}`}
-              coverImage={p.coverImage}
-              excerpt={p.excerpt}
-              date={p.date}
+              url={`/post/${p.slug}`}
+              type="blog"
+              thumbnail={p.coverImage}
+              authorName={p.authorName}
+              authorImage={p.authorImage}
+              metadata={p.date ? new Date(p.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" }) : undefined}
             />
           ))}
         </div>

--- a/apps/web/src/components/SocialMeta.astro
+++ b/apps/web/src/components/SocialMeta.astro
@@ -1,0 +1,54 @@
+---
+interface Props {
+  title: string;
+  description?: string;
+  ogImage?: string;
+  type?: 'website' | 'article';
+  publishedAt?: string;
+  author?: string;
+  canonicalUrl?: string;
+}
+
+const {
+  title,
+  description = "CodingCat.dev — Purrfect Web Tutorials",
+  ogImage,
+  type = "website",
+  publishedAt,
+  author,
+  canonicalUrl,
+} = Astro.props;
+
+const siteUrl = Astro.url.origin;
+const resolvedUrl = canonicalUrl || Astro.url.href;
+const resolvedImage = ogImage || `${siteUrl}/api/og/default.png?title=${encodeURIComponent(title)}`;
+---
+
+{/* Primary Meta Tags */}
+<meta name="description" content={description} />
+
+{/* Canonical */}
+{canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
+
+{/* Open Graph */}
+<meta property="og:type" content={type} />
+<meta property="og:url" content={resolvedUrl} />
+<meta property="og:title" content={title} />
+<meta property="og:description" content={description} />
+<meta property="og:image" content={resolvedImage} />
+<meta property="og:site_name" content="CodingCat.dev" />
+
+{/* Twitter Card */}
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:site" content="@codingcatdev" />
+<meta name="twitter:title" content={title} />
+<meta name="twitter:description" content={description} />
+<meta name="twitter:image" content={resolvedImage} />
+
+{/* Article-specific */}
+{type === "article" && publishedAt && (
+  <meta property="article:published_time" content={publishedAt} />
+)}
+{type === "article" && author && (
+  <meta property="article:author" content={author} />
+)}

--- a/apps/web/src/components/SocialMeta.astro
+++ b/apps/web/src/components/SocialMeta.astro
@@ -36,7 +36,11 @@ const resolvedImage = ogImage || `${siteUrl}/api/og/default.png?title=${encodeUR
 <meta property="og:title" content={title} />
 <meta property="og:description" content={description} />
 <meta property="og:image" content={resolvedImage} />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:alt" content={title} />
 <meta property="og:site_name" content="CodingCat.dev" />
+<meta property="og:locale" content="en_US" />
 
 {/* Twitter Card */}
 <meta name="twitter:card" content="summary_large_image" />

--- a/apps/web/src/layouts/BaseLayout.astro
+++ b/apps/web/src/layouts/BaseLayout.astro
@@ -4,13 +4,19 @@ import ThemeScript from "../components/ThemeScript.astro";
 import Header from "../components/Header.astro";
 import Footer from "../components/Footer.astro";
 import { VisualEditing } from "@sanity/astro/visual-editing";
+import SocialMeta from "../components/SocialMeta.astro";
 
 interface Props {
   title: string;
   description?: string;
+  ogImage?: string;
+  ogType?: 'website' | 'article';
+  publishedAt?: string;
+  author?: string;
+  canonicalUrl?: string;
 }
 
-const { title, description = "CodingCat.dev — Purrfect Web Tutorials" } = Astro.props;
+const { title, description = "CodingCat.dev — Purrfect Web Tutorials", ogImage, ogType, publishedAt, author, canonicalUrl } = Astro.props;
 
 const visualEditingEnabled =
   import.meta.env.PUBLIC_SANITY_VISUAL_EDITING_ENABLED === "true" ||
@@ -22,7 +28,15 @@ const visualEditingEnabled =
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content={description} />
+    <SocialMeta
+      title={title}
+      description={description}
+      ogImage={ogImage}
+      type={ogType}
+      publishedAt={publishedAt}
+      author={author}
+      canonicalUrl={canonicalUrl}
+    />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="alternate" type="application/rss+xml" title="CodingCat.dev Blog" href="/rss.xml" />
     <link rel="alternate" type="application/rss+xml" title="CodingCat.dev Podcast" href="/podcast/rss.xml" />

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -63,13 +63,10 @@ const podcastFields = `
   chapters[]{
     title,
     timestamp,
-    description
+    seconds
   },
   "series": series->{ _id, "title": coalesce(title, "Unknown Series"), "slug": slug.current, description },
-  listenLinks[]{
-    platform,
-    url
-  }
+  listenLinks
 `;
 
 export const homePageQuery = groq`*[_type == "settings"][0]{
@@ -232,7 +229,10 @@ export const sitemapQuery = groq`*[_type in ["author", "guest", "page", "podcast
 // Generic pages (Sanity "page" type)
 export const pageQuery = groq`*[_type == "page" && slug.current == $slug][0] {
   ${baseFields},
-  ${contentFields}
+  ${contentFields},
+  "ogTitle": socialPreview.ogTitle,
+  "ogDescription": socialPreview.ogDescription,
+  "ogImage": socialPreview.ogImage
 }`;
 
 // RSS feeds

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -7,7 +7,9 @@ const baseFields = `
   "slug": slug.current,
   excerpt,
   coverImage,
-  "date": coalesce(date, _createdAt)
+  "date": coalesce(date, _createdAt),
+  "authorName": author[0]->title,
+  "authorImage": author[0]->coverImage
 `;
 
 const contentFields = `
@@ -57,12 +59,23 @@ const podcastFields = `
     name,
     site
   },
-  spotify
+  spotify,
+  chapters[]{
+    title,
+    timestamp,
+    description
+  },
+  "series": series->{ _id, "title": coalesce(title, "Unknown Series"), "slug": slug.current, description },
+  listenLinks[]{
+    platform,
+    url
+  }
 `;
 
 export const homePageQuery = groq`*[_type == "settings"][0]{
   "latestPodcast": *[_type == "podcast"]|order(date desc)[0]{
     ${baseFields},
+    excerpt,
     youtube,
   },
   "latestPodcasts": *[_type == "podcast"]|order(date desc)[0...4]{
@@ -84,18 +97,25 @@ export const postListQuery = groq`*[_type == "post" && defined(slug.current)] | 
   author[]->{
     "title": coalesce(title, "Anonymous"),
     "slug": slug.current,
-  }
+  },
+  categories[]->{ _id, "title": coalesce(title, "Uncategorized"), "slug": slug.current }
 }`;
 
 export const postQuery = groq`*[_type == "post" && slug.current == $slug][0] {
   ${baseFields},
-  ${contentFields}
+  ${contentFields},
+  categories[]->{ _id, "title": coalesce(title, "Uncategorized"), "slug": slug.current },
+  "ogTitle": socialPreview.ogTitle,
+  "ogDescription": socialPreview.ogDescription,
+  "ogImage": socialPreview.ogImage
 }`;
 
 export const postCountQuery = groq`count(*[_type == "post" && defined(slug.current)])`;
 
 export const podcastListQuery = groq`*[_type == "podcast" && defined(slug.current)] | order(date desc, _updatedAt desc) [$offset...$end] {
   ${baseFields},
+  episode,
+  season,
   author[]->{
     "title": coalesce(title, "Anonymous"),
     "slug": slug.current,
@@ -109,7 +129,10 @@ export const podcastListQuery = groq`*[_type == "podcast" && defined(slug.curren
 export const podcastQuery = groq`*[_type == "podcast" && slug.current == $slug][0] {
   ${baseFields},
   ${contentFields},
-  ${podcastFields}
+  ${podcastFields},
+  "ogTitle": socialPreview.ogTitle,
+  "ogDescription": socialPreview.ogDescription,
+  "ogImage": socialPreview.ogImage
 }`;
 
 export const podcastCountQuery = groq`count(*[_type == "podcast" && defined(slug.current)])`;
@@ -131,6 +154,11 @@ export const authorQuery = groq`*[_type == "author" && slug.current == $slug][0]
   ${contentFields},
   socials,
   websites,
+  company,
+  role,
+  "ogTitle": socialPreview.ogTitle,
+  "ogDescription": socialPreview.ogDescription,
+  "ogImage": socialPreview.ogImage,
   "related": {
     "podcast": *[_type == "podcast" && (^._id in author[]._ref || ^._id in guest[]._ref)] | order(date desc) [0...4] {
       ${baseFields}
@@ -153,6 +181,11 @@ export const guestQuery = groq`*[_type == "guest" && slug.current == $slug][0] {
   ${contentFields},
   socials,
   websites,
+  company,
+  role,
+  "ogTitle": socialPreview.ogTitle,
+  "ogDescription": socialPreview.ogDescription,
+  "ogImage": socialPreview.ogImage,
   "related": {
     "podcast": *[_type == "podcast" && (^._id in author[]._ref || ^._id in guest[]._ref)] | order(date desc) [0...4] {
       ${baseFields}
@@ -175,6 +208,9 @@ export const sponsorQuery = groq`*[_type == "sponsor" && slug.current == $slug][
   ${contentFields},
   socials,
   websites,
+  "ogTitle": socialPreview.ogTitle,
+  "ogDescription": socialPreview.ogDescription,
+  "ogImage": socialPreview.ogImage,
   "related": {
     "podcast": *[_type == "podcast" && ^._id in sponsor[]._ref] | order(date desc) [0...4] {
       ${baseFields}

--- a/apps/web/src/pages/404.astro
+++ b/apps/web/src/pages/404.astro
@@ -1,20 +1,27 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
+import Container from "@/components/Container.astro";
+import Button from "@/components/Button.astro";
 ---
 
 <BaseLayout title="Page Not Found — CodingCat.dev">
-  <main class="container mx-auto px-4 py-16 text-center">
-    <h1 class="text-6xl font-bold mb-4">404</h1>
-    <p class="text-xl text-gray-600 mb-8">
-      This page has gone on a catnap. 😸
-    </p>
-    <div class="space-x-4">
-      <a href="/" class="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors">
-        Go Home
-      </a>
-      <a href="/blog" class="px-6 py-3 border rounded-lg hover:bg-gray-50 transition-colors">
-        Browse Blog
-      </a>
-    </div>
+  <main class="py-20 md:py-32">
+    <Container>
+      <div class="text-center max-w-lg mx-auto">
+        <p class="text-8xl md:text-9xl font-extrabold bg-gradient-to-r from-primary to-primary/50 bg-clip-text text-transparent mb-6">
+          404
+        </p>
+        <h1 class="text-2xl md:text-3xl font-bold text-[--text] mb-3">
+          Page Not Found
+        </h1>
+        <p class="text-lg text-[--text-secondary] mb-8">
+          This page has gone on a catnap. 😸 Maybe it's chasing a laser pointer somewhere else.
+        </p>
+        <div class="flex flex-wrap justify-center gap-4">
+          <Button href="/" variant="primary" size="lg">Go Home</Button>
+          <Button href="/blog" variant="secondary" size="lg">Browse Blog</Button>
+        </div>
+      </div>
+    </Container>
   </main>
 </BaseLayout>

--- a/apps/web/src/pages/[slug].astro
+++ b/apps/web/src/pages/[slug].astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
+import Container from "@/components/Container.astro";
 import { PortableText } from "astro-portabletext";
 import { loadQuery, urlForImage } from "@/utils/sanity";
 import { pageQuery } from "@/lib/queries";
@@ -24,24 +25,39 @@ if (!page) {
 const coverUrl = page.coverImage
   ? urlForImage(page.coverImage).width(1200).height(630).format("webp").url()
   : null;
+
+const siteUrl = Astro.url.origin;
+const ogImage = `${siteUrl}/api/og/default.png?title=${encodeURIComponent(page.title)}`;
 ---
 
-<BaseLayout title={`${page.title} — CodingCat.dev`} description={page.excerpt}>
-  <article class="container mx-auto px-4 py-8 max-w-4xl">
-    <h1 class="text-4xl font-bold mb-8">{page.title}</h1>
+<BaseLayout title={`${page.title} — CodingCat.dev`} description={page.excerpt} ogImage={ogImage}>
+  <article class="py-12">
+    <Container size="narrow">
+      <h1 class="text-4xl font-bold text-[--text] mb-8">{page.title}</h1>
 
-    {coverUrl && (
-      <img
-        src={coverUrl}
-        alt={page.title}
-        width={1200}
-        height={630}
-        class="w-full rounded-lg mb-8"
-      />
-    )}
+      {coverUrl && (
+        <img
+          src={coverUrl}
+          alt={page.title}
+          width={1200}
+          height={630}
+          class="w-full rounded-xl mb-8"
+        />
+      )}
 
-    <div class="prose prose-lg max-w-none">
-      {page.content && <PortableText value={page.content} />}
-    </div>
+      <div class="prose prose-lg prose-invert max-w-none
+        prose-headings:text-[--text] prose-headings:font-bold
+        prose-p:text-[--text-secondary]
+        prose-a:text-primary prose-a:no-underline hover:prose-a:underline
+        prose-strong:text-[--text]
+        prose-code:text-primary prose-code:bg-[--surface] prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded
+        prose-pre:bg-[--surface] prose-pre:border prose-pre:border-[--border] prose-pre:rounded-xl
+        prose-blockquote:border-primary prose-blockquote:text-[--text-secondary]
+        prose-li:text-[--text-secondary]
+        prose-img:rounded-xl
+      ">
+        {page.content && <PortableText value={page.content} />}
+      </div>
+    </Container>
   </article>
 </BaseLayout>

--- a/apps/web/src/pages/[slug].astro
+++ b/apps/web/src/pages/[slug].astro
@@ -27,10 +27,14 @@ const coverUrl = page.coverImage
   : null;
 
 const siteUrl = Astro.url.origin;
-const ogImage = `${siteUrl}/api/og/default.png?title=${encodeURIComponent(page.title)}`;
+const displayTitle = page.ogTitle || page.title;
+const displayDescription = page.ogDescription || page.excerpt;
+const ogImage = page.ogImage
+  ? urlForImage(page.ogImage).width(1200).height(630).url()
+  : `${siteUrl}/api/og/default.png?title=${encodeURIComponent(page.title)}`;
 ---
 
-<BaseLayout title={`${page.title} — CodingCat.dev`} description={page.excerpt} ogImage={ogImage}>
+<BaseLayout title={`${displayTitle} — CodingCat.dev`} description={displayDescription} ogImage={ogImage}>
   <article class="py-12">
     <Container size="narrow">
       <h1 class="text-4xl font-bold text-[--text] mb-8">{page.title}</h1>

--- a/apps/web/src/pages/author/[slug].astro
+++ b/apps/web/src/pages/author/[slug].astro
@@ -1,7 +1,8 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
+import Container from "@/components/Container.astro";
 import PersonDetail from "@/components/PersonDetail.astro";
-import { loadQuery } from "@/utils/sanity";
+import { loadQuery, urlForImage } from "@/utils/sanity";
 import { authorQuery } from "@/lib/queries";
 
 export const prerender = false;
@@ -13,10 +14,19 @@ const { data: author } = await loadQuery<any>({ query: authorQuery, params: { sl
 if (!author) {
   return Astro.redirect("/404");
 }
+
+const siteUrl = Astro.url.origin;
+const displayTitle = author.ogTitle || author.title;
+const displayDescription = author.ogDescription || author.excerpt;
+const ogImage = author.ogImage
+  ? urlForImage(author.ogImage).width(1200).height(630).url()
+  : `${siteUrl}/api/og/default.png?title=${encodeURIComponent(author.title)}&subtitle=${encodeURIComponent("Author at CodingCat.dev")}`;
 ---
 
-<BaseLayout title={`${author.title} — CodingCat.dev`} description={author.excerpt}>
-  <main class="container mx-auto px-4 py-8 max-w-4xl">
-    <PersonDetail person={author} type="author" />
+<BaseLayout title={`${displayTitle} — CodingCat.dev`} description={displayDescription} ogImage={ogImage}>
+  <main class="py-12">
+    <Container>
+      <PersonDetail person={author} type="author" />
+    </Container>
   </main>
 </BaseLayout>

--- a/apps/web/src/pages/authors.astro
+++ b/apps/web/src/pages/authors.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
+import Container from "@/components/Container.astro";
 import ContentCard from "@/components/ContentCard.astro";
 import Pagination from "@/components/Pagination.astro";
 import { loadQuery, sanityFetch } from "@/utils/sanity";
@@ -24,27 +25,34 @@ const totalPages = Math.ceil(totalCount / perPage);
 if (page > totalPages && totalPages > 0) {
   return Astro.redirect(`/authors?page=${totalPages}`);
 }
+
+const siteUrl = Astro.url.origin;
+const ogImage = `${siteUrl}/api/og/default.png?title=${encodeURIComponent("Authors")}&subtitle=${encodeURIComponent("The People Behind CodingCat.dev")}`;
 ---
 
-<BaseLayout title="Authors — CodingCat.dev">
-  <main class="container mx-auto px-4 py-8">
-    <h1 class="text-4xl font-bold mb-2">Authors</h1>
-    <p class="text-gray-600 mb-8">The people behind CodingCat.dev content.</p>
+<BaseLayout title="Authors — CodingCat.dev" ogImage={ogImage}>
+  <main class="py-12">
+    <Container>
+      <div class="mb-8">
+        <h1 class="text-4xl font-bold text-[--text] mb-2">Authors</h1>
+        <p class="text-[--text-secondary] text-lg">The people behind CodingCat.dev content.</p>
+      </div>
 
-    <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-      {items?.map((item) => (
-        <ContentCard
-          title={item.title}
-          slug={`/author/${item.slug}`}
-          coverImage={item.coverImage}
-          excerpt={item.excerpt}
-          date={item.date}
-        />
-      ))}
-    </div>
+      <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {items?.map((item: any) => (
+          <ContentCard
+            title={item.title}
+            url={`/author/${item.slug}`}
+            type="blog"
+            thumbnail={item.coverImage}
+            metadata={item.date ? new Date(item.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" }) : undefined}
+          />
+        ))}
+      </div>
 
-    {totalPages > 1 && (
-      <Pagination currentPage={page} totalPages={totalPages} basePath="/authors" />
-    )}
+      {totalPages > 1 && (
+        <Pagination currentPage={page} totalPages={totalPages} basePath="/authors" />
+      )}
+    </Container>
   </main>
 </BaseLayout>

--- a/apps/web/src/pages/blog.astro
+++ b/apps/web/src/pages/blog.astro
@@ -1,13 +1,16 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
+import Container from "@/components/Container.astro";
 import ContentCard from "@/components/ContentCard.astro";
+import Badge from "@/components/Badge.astro";
+import Tag from "@/components/Tag.astro";
 import Pagination from "@/components/Pagination.astro";
 import { loadQuery, sanityFetch } from "@/utils/sanity";
 import { postListQuery, postCountQuery } from "@/lib/queries";
 
 export const prerender = false;
 
-// B1: Validate page number — clamp to positive integer
+// Validate page number — clamp to positive integer
 const rawPage = Number(Astro.url.searchParams.get("page") || "1");
 const page = Number.isNaN(rawPage) || rawPage < 1 ? 1 : Math.floor(rawPage);
 const perPage = 12;
@@ -26,27 +29,55 @@ const totalPages = Math.ceil(totalCount / perPage);
 if (page > totalPages && totalPages > 0) {
   return Astro.redirect(`/blog?page=${totalPages}`);
 }
+
+const siteUrl = Astro.url.origin;
+const ogImage = `${siteUrl}/api/og/default.png?title=${encodeURIComponent("Blog")}&subtitle=${encodeURIComponent("Web Development Tutorials")}`;
+
+function formatDate(date: string): string {
+  return new Date(date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+}
 ---
 
-<BaseLayout title="Blog — CodingCat.dev">
-  <main class="container mx-auto px-4 py-8">
-    <h1 class="text-4xl font-bold mb-2">Blog</h1>
-    <p class="text-gray-600 mb-8">Web development tutorials, tips, and insights.</p>
+<BaseLayout title="Blog — CodingCat.dev" ogImage={ogImage}>
+  <main class="py-12">
+    <Container>
+      {/* Header */}
+      <div class="mb-8">
+        <div class="flex items-center gap-3 mb-2">
+          <Badge type="blog" />
+          <span class="text-sm text-[--text-tertiary]">{totalCount} posts</span>
+        </div>
+        <h1 class="text-4xl font-bold text-[--text] mb-2">Blog</h1>
+        <p class="text-[--text-secondary] text-lg">Web development tutorials, tips, and insights.</p>
+      </div>
 
-    <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-      {posts?.map((post) => (
-        <ContentCard
-          title={post.title}
-          slug={`/post/${post.slug}`}
-          coverImage={post.coverImage}
-          excerpt={post.excerpt}
-          date={post.date}
-        />
-      ))}
-    </div>
+      {/* Post Grid */}
+      <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {posts?.map((post: any) => (
+          <div>
+            <ContentCard
+              title={post.title}
+              url={`/post/${post.slug}`}
+              type="blog"
+              thumbnail={post.coverImage}
+              authorName={post.authorName}
+              authorImage={post.authorImage}
+              metadata={post.date ? formatDate(post.date) : undefined}
+            />
+            {post.categories && post.categories.length > 0 && (
+              <div class="flex flex-wrap gap-1.5 mt-2 px-1">
+                {post.categories.map((cat: any) => (
+                  <Tag label={cat.title} href={`/topic/${cat.slug}`} />
+                ))}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
 
-    {totalPages > 1 && (
-      <Pagination currentPage={page} totalPages={totalPages} basePath="/blog" />
-    )}
+      {totalPages > 1 && (
+        <Pagination currentPage={page} totalPages={totalPages} basePath="/blog" />
+      )}
+    </Container>
   </main>
 </BaseLayout>

--- a/apps/web/src/pages/guest/[slug].astro
+++ b/apps/web/src/pages/guest/[slug].astro
@@ -1,7 +1,8 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
+import Container from "@/components/Container.astro";
 import PersonDetail from "@/components/PersonDetail.astro";
-import { loadQuery } from "@/utils/sanity";
+import { loadQuery, urlForImage } from "@/utils/sanity";
 import { guestQuery } from "@/lib/queries";
 
 export const prerender = false;
@@ -13,10 +14,19 @@ const { data: guest } = await loadQuery<any>({ query: guestQuery, params: { slug
 if (!guest) {
   return Astro.redirect("/404");
 }
+
+const siteUrl = Astro.url.origin;
+const displayTitle = guest.ogTitle || guest.title;
+const displayDescription = guest.ogDescription || guest.excerpt;
+const ogImage = guest.ogImage
+  ? urlForImage(guest.ogImage).width(1200).height(630).url()
+  : `${siteUrl}/api/og/default.png?title=${encodeURIComponent(guest.title)}&subtitle=${encodeURIComponent("Guest on CodingCat.dev")}`;
 ---
 
-<BaseLayout title={`${guest.title} — CodingCat.dev`} description={guest.excerpt}>
-  <main class="container mx-auto px-4 py-8 max-w-4xl">
-    <PersonDetail person={guest} type="guest" />
+<BaseLayout title={`${displayTitle} — CodingCat.dev`} description={displayDescription} ogImage={ogImage}>
+  <main class="py-12">
+    <Container>
+      <PersonDetail person={guest} type="guest" />
+    </Container>
   </main>
 </BaseLayout>

--- a/apps/web/src/pages/guests.astro
+++ b/apps/web/src/pages/guests.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
+import Container from "@/components/Container.astro";
 import ContentCard from "@/components/ContentCard.astro";
 import Pagination from "@/components/Pagination.astro";
 import { loadQuery, sanityFetch } from "@/utils/sanity";
@@ -24,27 +25,34 @@ const totalPages = Math.ceil(totalCount / perPage);
 if (page > totalPages && totalPages > 0) {
   return Astro.redirect(`/guests?page=${totalPages}`);
 }
+
+const siteUrl = Astro.url.origin;
+const ogImage = `${siteUrl}/api/og/default.png?title=${encodeURIComponent("Guests")}&subtitle=${encodeURIComponent("Industry Experts on CodingCat.dev")}`;
 ---
 
-<BaseLayout title="Guests — CodingCat.dev">
-  <main class="container mx-auto px-4 py-8">
-    <h1 class="text-4xl font-bold mb-2">Guests</h1>
-    <p class="text-gray-600 mb-8">The people behind CodingCat.dev content.</p>
+<BaseLayout title="Guests — CodingCat.dev" ogImage={ogImage}>
+  <main class="py-12">
+    <Container>
+      <div class="mb-8">
+        <h1 class="text-4xl font-bold text-[--text] mb-2">Guests</h1>
+        <p class="text-[--text-secondary] text-lg">Industry experts who have joined us on the podcast.</p>
+      </div>
 
-    <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-      {items?.map((item) => (
-        <ContentCard
-          title={item.title}
-          slug={`/guest/${item.slug}`}
-          coverImage={item.coverImage}
-          excerpt={item.excerpt}
-          date={item.date}
-        />
-      ))}
-    </div>
+      <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {items?.map((item: any) => (
+          <ContentCard
+            title={item.title}
+            url={`/guest/${item.slug}`}
+            type="podcast"
+            thumbnail={item.coverImage}
+            metadata={item.date ? new Date(item.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" }) : undefined}
+          />
+        ))}
+      </div>
 
-    {totalPages > 1 && (
-      <Pagination currentPage={page} totalPages={totalPages} basePath="/guests" />
-    )}
+      {totalPages > 1 && (
+        <Pagination currentPage={page} totalPages={totalPages} basePath="/guests" />
+      )}
+    </Container>
   </main>
 </BaseLayout>

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -1,6 +1,10 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
+import Container from "@/components/Container.astro";
+import ContentCardFeatured from "@/components/ContentCardFeatured.astro";
 import ContentCard from "@/components/ContentCard.astro";
+import Badge from "@/components/Badge.astro";
+import Button from "@/components/Button.astro";
 import { loadQuery } from "@/utils/sanity";
 import { homePageQuery } from "@/lib/queries";
 
@@ -8,91 +12,166 @@ export const prerender = false;
 
 const draftMode = Astro.cookies.has("__sanity_preview");
 const { data: homePage } = await loadQuery<any>({ query: homePageQuery, draftMode });
+
+const siteUrl = Astro.url.origin;
+const ogImage = `${siteUrl}/api/og/default.png?title=${encodeURIComponent("CodingCat.dev")}&subtitle=${encodeURIComponent("Purrfect Web Development Tutorials")}`;
+
+function formatDate(date: string): string {
+  return new Date(date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+}
 ---
 
-<BaseLayout title="CodingCat.dev — Purrfect Web Tutorials">
-  <main class="container mx-auto px-4 py-8">
-    <!-- Hero -->
-    <section class="text-center py-16">
-      <h1 class="text-5xl font-bold mb-4">CodingCat.dev</h1>
-      <p class="text-xl text-gray-600 max-w-2xl mx-auto">
-        Purrfect Web Development Tutorials — Podcasts, Blog Posts, and Courses
-      </p>
+<BaseLayout title="CodingCat.dev — Purrfect Web Tutorials" ogImage={ogImage}>
+  <main>
+    {/* Hero Section */}
+    <section class="bg-gradient-to-b from-primary/10 to-transparent py-20 md:py-28">
+      <Container size="wide">
+        <div class="text-center max-w-3xl mx-auto">
+          <h1 class="text-5xl md:text-6xl font-extrabold text-[--text] mb-6">
+            CodingCat<span class="text-primary">.dev</span>
+          </h1>
+          <p class="text-xl md:text-2xl text-[--text-secondary] mb-8">
+            Purrfect Web Development Tutorials — Podcasts, Blog Posts, and Courses
+          </p>
+          <div class="flex flex-wrap justify-center gap-4">
+            <Button href="/podcasts" variant="primary" size="lg">Latest Podcasts</Button>
+            <Button href="/blog" variant="secondary" size="lg">Browse Blog</Button>
+          </div>
+        </div>
+      </Container>
     </section>
 
-    <!-- Latest Podcasts -->
+    {/* Featured Latest Podcast */}
+    {homePage?.latestPodcast && (
+      <section class="py-12">
+        <Container size="wide">
+          <div class="flex items-center gap-3 mb-6">
+            <Badge type="podcast" />
+            <h2 class="text-2xl font-bold text-[--text]">Latest Episode</h2>
+          </div>
+          <ContentCardFeatured
+            title={homePage.latestPodcast.title}
+            url={`/podcast/${homePage.latestPodcast.slug}`}
+            type="podcast"
+            thumbnail={homePage.latestPodcast.coverImage}
+            authorName={homePage.latestPodcast.authorName}
+            authorImage={homePage.latestPodcast.authorImage}
+            excerpt={homePage.latestPodcast.excerpt}
+            metadata={homePage.latestPodcast.date ? formatDate(homePage.latestPodcast.date) : undefined}
+          />
+        </Container>
+      </section>
+    )}
+
+    {/* Latest Podcasts */}
     {homePage?.latestPodcasts && homePage.latestPodcasts.length > 0 && (
-      <section class="mb-16">
-        <h2 class="text-3xl font-bold mb-2">Latest Podcasts</h2>
-        <p class="text-gray-600 mb-8">Check out our latest podcasts.</p>
-        <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
-          {homePage.latestPodcasts.map((podcast: any) => (
-            <ContentCard
-              title={podcast.title}
-              slug={`/podcast/${podcast.slug}`}
-              coverImage={podcast.coverImage}
-              excerpt={podcast.excerpt}
-              date={podcast.date}
-            />
-          ))}
-        </div>
+      <section class="py-12">
+        <Container size="wide">
+          <div class="flex items-center justify-between mb-6">
+            <div class="flex items-center gap-3">
+              <Badge type="podcast" />
+              <h2 class="text-2xl font-bold text-[--text]">Latest Podcasts</h2>
+            </div>
+            <a href="/podcasts" class="text-sm font-medium text-primary hover:underline">View All →</a>
+          </div>
+          <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+            {homePage.latestPodcasts.map((podcast: any) => (
+              <ContentCard
+                title={podcast.title}
+                url={`/podcast/${podcast.slug}`}
+                type="podcast"
+                thumbnail={podcast.coverImage}
+                authorName={podcast.authorName}
+                authorImage={podcast.authorImage}
+                metadata={podcast.date ? formatDate(podcast.date) : undefined}
+              />
+            ))}
+          </div>
+        </Container>
       </section>
     )}
 
-    <!-- Top Podcasts -->
+    {/* Top Podcasts */}
     {homePage?.topPodcasts && homePage.topPodcasts.length > 0 && (
-      <section class="mb-16">
-        <h2 class="text-3xl font-bold mb-2">Top Podcasts</h2>
-        <p class="text-gray-600 mb-8">Our most popular episodes by views.</p>
-        <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
-          {homePage.topPodcasts.map((podcast: any) => (
-            <ContentCard
-              title={podcast.title}
-              slug={`/podcast/${podcast.slug}`}
-              coverImage={podcast.coverImage}
-              excerpt={podcast.excerpt}
-              date={podcast.date}
-            />
-          ))}
-        </div>
+      <section class="py-12">
+        <Container size="wide">
+          <div class="flex items-center justify-between mb-6">
+            <div class="flex items-center gap-3">
+              <Badge type="podcast" />
+              <h2 class="text-2xl font-bold text-[--text]">Top Podcasts</h2>
+            </div>
+            <a href="/podcasts" class="text-sm font-medium text-primary hover:underline">View All →</a>
+          </div>
+          <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+            {homePage.topPodcasts.map((podcast: any) => (
+              <ContentCard
+                title={podcast.title}
+                url={`/podcast/${podcast.slug}`}
+                type="podcast"
+                thumbnail={podcast.coverImage}
+                authorName={podcast.authorName}
+                authorImage={podcast.authorImage}
+                metadata={podcast.date ? formatDate(podcast.date) : undefined}
+              />
+            ))}
+          </div>
+        </Container>
       </section>
     )}
 
-    <!-- Latest Posts -->
+    {/* Latest Posts */}
     {homePage?.latestPosts && homePage.latestPosts.length > 0 && (
-      <section class="mb-16">
-        <h2 class="text-3xl font-bold mb-2">From the Blog</h2>
-        <p class="text-gray-600 mb-8">Latest blog posts on web development.</p>
-        <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
-          {homePage.latestPosts.map((post: any) => (
-            <ContentCard
-              title={post.title}
-              slug={`/post/${post.slug}`}
-              coverImage={post.coverImage}
-              excerpt={post.excerpt}
-              date={post.date}
-            />
-          ))}
-        </div>
+      <section class="py-12">
+        <Container size="wide">
+          <div class="flex items-center justify-between mb-6">
+            <div class="flex items-center gap-3">
+              <Badge type="blog" />
+              <h2 class="text-2xl font-bold text-[--text]">From the Blog</h2>
+            </div>
+            <a href="/blog" class="text-sm font-medium text-primary hover:underline">View All →</a>
+          </div>
+          <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+            {homePage.latestPosts.map((post: any) => (
+              <ContentCard
+                title={post.title}
+                url={`/post/${post.slug}`}
+                type="blog"
+                thumbnail={post.coverImage}
+                authorName={post.authorName}
+                authorImage={post.authorImage}
+                metadata={post.date ? formatDate(post.date) : undefined}
+              />
+            ))}
+          </div>
+        </Container>
       </section>
     )}
 
-    <!-- Top Posts -->
+    {/* Top Posts */}
     {homePage?.topPosts && homePage.topPosts.length > 0 && (
-      <section class="mb-16">
-        <h2 class="text-3xl font-bold mb-2">Top Posts</h2>
-        <p class="text-gray-600 mb-8">Most viewed blog posts.</p>
-        <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
-          {homePage.topPosts.map((post: any) => (
-            <ContentCard
-              title={post.title}
-              slug={`/post/${post.slug}`}
-              coverImage={post.coverImage}
-              excerpt={post.excerpt}
-              date={post.date}
-            />
-          ))}
-        </div>
+      <section class="py-12">
+        <Container size="wide">
+          <div class="flex items-center justify-between mb-6">
+            <div class="flex items-center gap-3">
+              <Badge type="blog" />
+              <h2 class="text-2xl font-bold text-[--text]">Top Posts</h2>
+            </div>
+            <a href="/blog" class="text-sm font-medium text-primary hover:underline">View All →</a>
+          </div>
+          <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+            {homePage.topPosts.map((post: any) => (
+              <ContentCard
+                title={post.title}
+                url={`/post/${post.slug}`}
+                type="blog"
+                thumbnail={post.coverImage}
+                authorName={post.authorName}
+                authorImage={post.authorImage}
+                metadata={post.date ? formatDate(post.date) : undefined}
+              />
+            ))}
+          </div>
+        </Container>
       </section>
     )}
   </main>

--- a/apps/web/src/pages/podcast/[slug].astro
+++ b/apps/web/src/pages/podcast/[slug].astro
@@ -1,5 +1,10 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
+import Container from "@/components/Container.astro";
+import Badge from "@/components/Badge.astro";
+import Tag from "@/components/Tag.astro";
+import Avatar from "@/components/Avatar.astro";
+import Button from "@/components/Button.astro";
 import { PortableText } from "astro-portabletext";
 import { loadQuery, urlForImage } from "@/utils/sanity";
 import { podcastQuery } from "@/lib/queries";
@@ -25,100 +30,255 @@ const formattedDate = podcast.date
       day: "numeric",
     })
   : null;
+
+const firstAuthor = podcast.author?.[0];
+const authorImageUrl = firstAuthor?.coverImage
+  ? urlForImage(firstAuthor.coverImage).width(96).height(96).url()
+  : undefined;
+
+const siteUrl = Astro.url.origin;
+const displayTitle = podcast.ogTitle || podcast.title;
+const displayDescription = podcast.ogDescription || podcast.excerpt;
+const ogImage = podcast.ogImage
+  ? urlForImage(podcast.ogImage).width(1200).height(630).url()
+  : `${siteUrl}/api/og/podcast.png?title=${encodeURIComponent(podcast.title)}&author=${encodeURIComponent(firstAuthor?.title || "")}&episodeNumber=${podcast.episode || ""}`;
+
+const episodeLabel = podcast.season && podcast.episode
+  ? `Season ${podcast.season} · Episode ${podcast.episode}`
+  : podcast.episode
+    ? `Episode ${podcast.episode}`
+    : null;
+
+// Platform icons for listen links
+const platformLabels: Record<string, string> = {
+  spotify: "🎵 Spotify",
+  apple: "🍎 Apple Podcasts",
+  google: "🎧 Google Podcasts",
+  youtube: "▶️ YouTube",
+  overcast: "🔊 Overcast",
+  pocketcasts: "📻 Pocket Casts",
+};
 ---
 
-<BaseLayout title={`${podcast.title} — CodingCat.dev`} description={podcast.excerpt}>
-  <article class="container mx-auto px-4 py-8 max-w-4xl">
-    <header class="mb-8">
-      <h1 class="text-4xl font-bold mb-4">{podcast.title}</h1>
-      <div class="flex items-center gap-4 text-gray-600 flex-wrap">
-        {formattedDate && <time datetime={podcast.date}>{formattedDate}</time>}
-        {podcast.season && podcast.episode && (
-          <span>S{podcast.season}E{podcast.episode}</span>
-        )}
-        {podcast.author?.map((a: any) => (
-          <a href={`/author/${a.slug}`} class="hover:text-blue-600">{a.title}</a>
-        ))}
-      </div>
-    </header>
-
-    {coverUrl && (
-      <img
-        src={coverUrl}
-        alt={podcast.title}
-        width={1200}
-        height={630}
-        class="w-full rounded-lg mb-8"
-      />
-    )}
-
-    {podcast.youtube && (
-      <div class="aspect-video mb-8">
-        <iframe
-          src={`https://www.youtube.com/embed/${podcast.youtube}`}
-          class="w-full h-full rounded-lg"
-          allowfullscreen
-          loading="lazy"
-        />
-      </div>
-    )}
-
-    {podcast.spotify && (
-      <div class="mb-8">
-        <iframe
-          src={`https://open.spotify.com/embed/episode/${podcast.spotify}`}
-          width="100%"
-          height="152"
-          allow="encrypted-media"
-          loading="lazy"
-          class="rounded-lg"
-        />
-      </div>
-    )}
-
-    {podcast.guest && podcast.guest.length > 0 && (
-      <div class="mb-8">
-        <h2 class="text-xl font-semibold mb-4">Guests</h2>
-        <div class="flex flex-wrap gap-4">
-          {podcast.guest.map((g: any) => (
-            <a href={`/guest/${g.slug}`} class="px-4 py-2 bg-gray-100 rounded-lg hover:bg-gray-200 transition-colors">
-              {g.title}
-            </a>
-          ))}
+<BaseLayout
+  title={`${displayTitle} — CodingCat.dev`}
+  description={displayDescription}
+  ogImage={ogImage}
+  ogType="article"
+  publishedAt={podcast.date}
+  author={firstAuthor?.title}
+>
+  <article class="py-12">
+    <Container size="narrow">
+      {/* Header */}
+      <header class="mb-8">
+        <div class="flex flex-wrap items-center gap-3 mb-4">
+          <Badge type="podcast" />
+          {episodeLabel && (
+            <span class="text-sm font-medium text-[--color-type-podcast]">{episodeLabel}</span>
+          )}
+          {formattedDate && (
+            <time datetime={podcast.date} class="text-sm text-[--text-tertiary]">{formattedDate}</time>
+          )}
         </div>
-      </div>
-    )}
 
-    <div class="prose prose-lg max-w-none">
-      {podcast.content && <PortableText value={podcast.content} />}
-    </div>
+        <h1 class="text-4xl md:text-5xl font-bold text-[--text] mb-4">{podcast.title}</h1>
 
-    {podcast.pick && podcast.pick.length > 0 && (
-      <div class="mt-8">
-        <h2 class="text-xl font-semibold mb-4">Picks</h2>
-        <ul class="space-y-2">
-          {podcast.pick.map((p: any) => (
-            <li>
-              <strong>{p.user?.title || "Unknown"}:</strong>{" "}
-              {p.site ? (
-                <a href={p.site} target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:underline">
-                  {p.name}
+        {podcast.excerpt && (
+          <p class="text-lg text-[--text-secondary] mb-6">{podcast.excerpt}</p>
+        )}
+
+        {/* Author */}
+        <div class="flex flex-wrap items-center gap-4">
+          {podcast.author?.map((a: any) => {
+            const aImg = a.coverImage ? urlForImage(a.coverImage).width(48).height(48).url() : undefined;
+            return (
+              <a href={`/author/${a.slug}`} class="flex items-center gap-2 hover:text-primary transition-colors">
+                <Avatar src={aImg} name={a.title} size="sm" />
+                <span class="text-sm font-medium text-[--text-secondary]">{a.title}</span>
+              </a>
+            );
+          })}
+        </div>
+      </header>
+
+      {/* Series Info */}
+      {podcast.series && (
+        <div class="mb-8 p-4 rounded-xl bg-[--surface] border border-[--border]">
+          <p class="text-sm text-[--text-tertiary] mb-1">Part of series</p>
+          <p class="font-semibold text-[--text]">{podcast.series.title}</p>
+          {podcast.series.description && (
+            <p class="text-sm text-[--text-secondary] mt-1">{podcast.series.description}</p>
+          )}
+        </div>
+      )}
+
+      {/* Cover Image */}
+      {coverUrl && (
+        <img
+          src={coverUrl}
+          alt={podcast.title}
+          width={1200}
+          height={630}
+          class="w-full rounded-xl mb-8 aspect-video object-cover"
+        />
+      )}
+
+      {/* YouTube Embed */}
+      {podcast.youtube && (
+        <div class="aspect-video mb-8 rounded-xl overflow-hidden">
+          <iframe
+            src={`https://www.youtube.com/embed/${podcast.youtube}`}
+            class="w-full h-full"
+            allowfullscreen
+            loading="lazy"
+          />
+        </div>
+      )}
+
+      {/* Spotify Embed */}
+      {podcast.spotify && (
+        <div class="mb-8">
+          <iframe
+            src={`https://open.spotify.com/embed/episode/${podcast.spotify}`}
+            width="100%"
+            height="152"
+            allow="encrypted-media"
+            loading="lazy"
+            class="rounded-xl"
+          />
+        </div>
+      )}
+
+      {/* Listen Links */}
+      {podcast.listenLinks && podcast.listenLinks.length > 0 && (
+        <div class="mb-8">
+          <h2 class="text-lg font-semibold text-[--text] mb-3">Listen On</h2>
+          <div class="flex flex-wrap gap-2">
+            {podcast.listenLinks.map((link: any) => (
+              <a
+                href={link.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="inline-flex items-center px-4 py-2 rounded-lg bg-[--surface] border border-[--border] text-sm font-medium text-[--text-secondary] hover:text-[--text] hover:border-[--border-hover] transition-colors"
+              >
+                {platformLabels[link.platform] || link.platform}
+              </a>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Guest Cards */}
+      {podcast.guest && podcast.guest.length > 0 && (
+        <div class="mb-8">
+          <h2 class="text-lg font-semibold text-[--text] mb-3">Guests</h2>
+          <div class="grid gap-3 sm:grid-cols-2">
+            {podcast.guest.map((g: any) => {
+              const gImg = g.coverImage ? urlForImage(g.coverImage).width(96).height(96).url() : undefined;
+              return (
+                <a
+                  href={`/guest/${g.slug}`}
+                  class="flex items-center gap-3 p-4 rounded-xl bg-[--surface] border border-[--border] hover:border-[--border-hover] transition-colors"
+                >
+                  <Avatar src={gImg} name={g.title} size="md" />
+                  <div>
+                    <p class="font-medium text-[--text]">{g.title}</p>
+                    {(g.company || g.role) && (
+                      <p class="text-sm text-[--text-tertiary]">
+                        {[g.role, g.company].filter(Boolean).join(" at ")}
+                      </p>
+                    )}
+                  </div>
                 </a>
-              ) : (
-                <span>{p.name}</span>
-              )}
-            </li>
-          ))}
-        </ul>
-      </div>
-    )}
+              );
+            })}
+          </div>
+        </div>
+      )}
 
-    {podcast.tags && podcast.tags.length > 0 && (
-      <div class="mt-8 flex flex-wrap gap-2">
-        {podcast.tags.map((tag: string) => (
-          <span class="px-3 py-1 bg-gray-100 rounded-full text-sm">{tag}</span>
-        ))}
+      {/* Chapters */}
+      {podcast.chapters && podcast.chapters.length > 0 && (
+        <div class="mb-8">
+          <h2 class="text-lg font-semibold text-[--text] mb-3">Chapters</h2>
+          <div class="space-y-1">
+            {podcast.chapters.map((chapter: any, index: number) => (
+              <div class="flex gap-3 p-3 rounded-lg hover:bg-[--surface] transition-colors">
+                <span class="text-sm font-mono text-primary flex-shrink-0 pt-0.5">
+                  {chapter.timestamp || `${String(index + 1).padStart(2, "0")}:00`}
+                </span>
+                <div>
+                  <p class="font-medium text-[--text]">{chapter.title}</p>
+                  {chapter.description && (
+                    <p class="text-sm text-[--text-tertiary] mt-0.5">{chapter.description}</p>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Content */}
+      <div class="prose prose-lg prose-invert max-w-none
+        prose-headings:text-[--text] prose-headings:font-bold
+        prose-p:text-[--text-secondary]
+        prose-a:text-primary prose-a:no-underline hover:prose-a:underline
+        prose-strong:text-[--text]
+        prose-code:text-primary prose-code:bg-[--surface] prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded
+        prose-pre:bg-[--surface] prose-pre:border prose-pre:border-[--border] prose-pre:rounded-xl
+        prose-blockquote:border-primary prose-blockquote:text-[--text-secondary]
+        prose-li:text-[--text-secondary]
+        prose-img:rounded-xl
+      ">
+        {podcast.content && <PortableText value={podcast.content} />}
       </div>
-    )}
+
+      {/* Picks */}
+      {podcast.pick && podcast.pick.length > 0 && (
+        <div class="mt-12 pt-8 border-t border-[--border]">
+          <h2 class="text-lg font-semibold text-[--text] mb-4">Picks</h2>
+          <div class="space-y-3">
+            {podcast.pick.map((p: any) => (
+              <div class="flex items-start gap-3 p-3 rounded-lg bg-[--surface] border border-[--border]">
+                <span class="font-medium text-[--text] flex-shrink-0">{p.user?.title || "Unknown"}:</span>
+                {p.site ? (
+                  <a href={p.site} target="_blank" rel="noopener noreferrer" class="text-primary hover:underline">
+                    {p.name}
+                  </a>
+                ) : (
+                  <span class="text-[--text-secondary]">{p.name}</span>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Tags */}
+      {podcast.tags && podcast.tags.length > 0 && (
+        <div class="mt-12 pt-8 border-t border-[--border]">
+          <h3 class="text-sm font-semibold text-[--text-tertiary] uppercase tracking-wider mb-3">Tags</h3>
+          <div class="flex flex-wrap gap-2">
+            {podcast.tags.map((tag: string) => (
+              <Tag label={tag} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Author Card */}
+      {firstAuthor && (
+        <div class="mt-12 pt-8 border-t border-[--border]">
+          <a href={`/author/${firstAuthor.slug}`} class="flex items-center gap-4 p-4 rounded-xl bg-[--surface] border border-[--border] hover:border-[--border-hover] transition-colors">
+            <Avatar src={authorImageUrl} name={firstAuthor.title} size="lg" />
+            <div>
+              <p class="font-semibold text-[--text]">{firstAuthor.title}</p>
+              <p class="text-sm text-[--text-secondary]">View all episodes →</p>
+            </div>
+          </a>
+        </div>
+      )}
+    </Container>
   </article>
 </BaseLayout>

--- a/apps/web/src/pages/podcast/[slug].astro
+++ b/apps/web/src/pages/podcast/[slug].astro
@@ -35,13 +35,14 @@ const firstAuthor = podcast.author?.[0];
 const authorImageUrl = firstAuthor?.coverImage
   ? urlForImage(firstAuthor.coverImage).width(96).height(96).url()
   : undefined;
+const firstGuest = podcast.guest?.[0];
 
 const siteUrl = Astro.url.origin;
 const displayTitle = podcast.ogTitle || podcast.title;
 const displayDescription = podcast.ogDescription || podcast.excerpt;
 const ogImage = podcast.ogImage
   ? urlForImage(podcast.ogImage).width(1200).height(630).url()
-  : `${siteUrl}/api/og/podcast.png?title=${encodeURIComponent(podcast.title)}&author=${encodeURIComponent(firstAuthor?.title || "")}&episodeNumber=${podcast.episode || ""}`;
+  : `${siteUrl}/api/og/podcast.png?title=${encodeURIComponent(podcast.title)}&author=${encodeURIComponent(firstAuthor?.title || "")}&episodeNumber=${podcast.episode || ""}&guest=${encodeURIComponent(firstGuest?.title || "")}`;
 
 const episodeLabel = podcast.season && podcast.episode
   ? `Season ${podcast.season} · Episode ${podcast.episode}`
@@ -49,15 +50,18 @@ const episodeLabel = podcast.season && podcast.episode
     ? `Episode ${podcast.episode}`
     : null;
 
-// Platform icons for listen links
+// Platform labels for listen links (keys match Sanity schema field names)
 const platformLabels: Record<string, string> = {
+  youtube: "▶️ YouTube",
   spotify: "🎵 Spotify",
   apple: "🍎 Apple Podcasts",
-  google: "🎧 Google Podcasts",
-  youtube: "▶️ YouTube",
   overcast: "🔊 Overcast",
-  pocketcasts: "📻 Pocket Casts",
+  pocketCasts: "📻 Pocket Casts",
+  rss: "📡 RSS Feed",
 };
+
+// Convert flat listenLinks object to array of [key, url] pairs
+const listenLinksEntries = Object.entries(podcast.listenLinks || {}).filter(([_, url]) => url) as [string, string][];
 ---
 
 <BaseLayout
@@ -151,18 +155,18 @@ const platformLabels: Record<string, string> = {
       )}
 
       {/* Listen Links */}
-      {podcast.listenLinks && podcast.listenLinks.length > 0 && (
+      {listenLinksEntries.length > 0 && (
         <div class="mb-8">
           <h2 class="text-lg font-semibold text-[--text] mb-3">Listen On</h2>
           <div class="flex flex-wrap gap-2">
-            {podcast.listenLinks.map((link: any) => (
+            {listenLinksEntries.map(([platform, url]) => (
               <a
-                href={link.url}
+                href={url}
                 target="_blank"
                 rel="noopener noreferrer"
                 class="inline-flex items-center px-4 py-2 rounded-lg bg-[--surface] border border-[--border] text-sm font-medium text-[--text-secondary] hover:text-[--text] hover:border-[--border-hover] transition-colors"
               >
-                {platformLabels[link.platform] || link.platform}
+                {platformLabels[platform] || platform}
               </a>
             ))}
           </div>
@@ -209,8 +213,8 @@ const platformLabels: Record<string, string> = {
                 </span>
                 <div>
                   <p class="font-medium text-[--text]">{chapter.title}</p>
-                  {chapter.description && (
-                    <p class="text-sm text-[--text-tertiary] mt-0.5">{chapter.description}</p>
+                  {chapter.seconds != null && (
+                    <span class="text-xs text-[--text-tertiary] mt-0.5">{Math.floor(chapter.seconds / 60)}m {chapter.seconds % 60}s</span>
                   )}
                 </div>
               </div>

--- a/apps/web/src/pages/podcasts.astro
+++ b/apps/web/src/pages/podcasts.astro
@@ -1,13 +1,15 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
+import Container from "@/components/Container.astro";
 import ContentCard from "@/components/ContentCard.astro";
+import Badge from "@/components/Badge.astro";
 import Pagination from "@/components/Pagination.astro";
 import { loadQuery, sanityFetch } from "@/utils/sanity";
 import { podcastListQuery, podcastCountQuery } from "@/lib/queries";
 
 export const prerender = false;
 
-// B1: Validate page number — clamp to positive integer
+// Validate page number — clamp to positive integer
 const rawPage = Number(Astro.url.searchParams.get("page") || "1");
 const page = Number.isNaN(rawPage) || rawPage < 1 ? 1 : Math.floor(rawPage);
 const perPage = 12;
@@ -26,27 +28,57 @@ const totalPages = Math.ceil(totalCount / perPage);
 if (page > totalPages && totalPages > 0) {
   return Astro.redirect(`/podcasts?page=${totalPages}`);
 }
+
+const siteUrl = Astro.url.origin;
+const ogImage = `${siteUrl}/api/og/default.png?title=${encodeURIComponent("Podcasts")}&subtitle=${encodeURIComponent("Web Development Conversations")}`;
+
+function formatDate(date: string): string {
+  return new Date(date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+}
+
+function formatMetadata(podcast: any): string {
+  const parts: string[] = [];
+  if (podcast.season && podcast.episode) {
+    parts.push(`S${podcast.season}E${podcast.episode}`);
+  }
+  if (podcast.date) {
+    parts.push(formatDate(podcast.date));
+  }
+  return parts.join(" · ");
+}
 ---
 
-<BaseLayout title="Podcasts — CodingCat.dev">
-  <main class="container mx-auto px-4 py-8">
-    <h1 class="text-4xl font-bold mb-2">Podcasts</h1>
-    <p class="text-gray-600 mb-8">Web development conversations with industry experts.</p>
+<BaseLayout title="Podcasts — CodingCat.dev" ogImage={ogImage}>
+  <main class="py-12">
+    <Container>
+      {/* Header */}
+      <div class="mb-8">
+        <div class="flex items-center gap-3 mb-2">
+          <Badge type="podcast" />
+          <span class="text-sm text-[--text-tertiary]">{totalCount} episodes</span>
+        </div>
+        <h1 class="text-4xl font-bold text-[--text] mb-2">Podcasts</h1>
+        <p class="text-[--text-secondary] text-lg">Web development conversations with industry experts.</p>
+      </div>
 
-    <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-      {podcasts?.map((podcast) => (
-        <ContentCard
-          title={podcast.title}
-          slug={`/podcast/${podcast.slug}`}
-          coverImage={podcast.coverImage}
-          excerpt={podcast.excerpt}
-          date={podcast.date}
-        />
-      ))}
-    </div>
+      {/* Podcast Grid */}
+      <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {podcasts?.map((podcast: any) => (
+          <ContentCard
+            title={podcast.title}
+            url={`/podcast/${podcast.slug}`}
+            type="podcast"
+            thumbnail={podcast.coverImage}
+            authorName={podcast.authorName}
+            authorImage={podcast.authorImage}
+            metadata={formatMetadata(podcast)}
+          />
+        ))}
+      </div>
 
-    {totalPages > 1 && (
-      <Pagination currentPage={page} totalPages={totalPages} basePath="/podcasts" />
-    )}
+      {totalPages > 1 && (
+        <Pagination currentPage={page} totalPages={totalPages} basePath="/podcasts" />
+      )}
+    </Container>
   </main>
 </BaseLayout>

--- a/apps/web/src/pages/post/[slug].astro
+++ b/apps/web/src/pages/post/[slug].astro
@@ -1,5 +1,9 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
+import Container from "@/components/Container.astro";
+import Badge from "@/components/Badge.astro";
+import Tag from "@/components/Tag.astro";
+import Avatar from "@/components/Avatar.astro";
 import { PortableText } from "astro-portabletext";
 import { loadQuery, urlForImage } from "@/utils/sanity";
 import { postQuery } from "@/lib/queries";
@@ -25,51 +29,129 @@ const formattedDate = post.date
       day: "numeric",
     })
   : null;
+
+const firstAuthor = post.author?.[0];
+const authorImageUrl = firstAuthor?.coverImage
+  ? urlForImage(firstAuthor.coverImage).width(96).height(96).url()
+  : undefined;
+
+const siteUrl = Astro.url.origin;
+const displayTitle = post.ogTitle || post.title;
+const displayDescription = post.ogDescription || post.excerpt;
+const ogImage = post.ogImage
+  ? urlForImage(post.ogImage).width(1200).height(630).url()
+  : `${siteUrl}/api/og/blog.png?title=${encodeURIComponent(post.title)}&author=${encodeURIComponent(firstAuthor?.title || "")}`;
 ---
 
-<BaseLayout title={`${post.title} — CodingCat.dev`} description={post.excerpt}>
-  <article class="container mx-auto px-4 py-8 max-w-4xl">
-    <header class="mb-8">
-      <h1 class="text-4xl font-bold mb-4">{post.title}</h1>
-      <div class="flex items-center gap-4 text-gray-600">
-        {formattedDate && <time datetime={post.date}>{formattedDate}</time>}
-        {post.author?.map((a: any) => (
-          <a href={`/author/${a.slug}`} class="hover:text-blue-600">{a.title}</a>
-        ))}
-      </div>
-    </header>
+<BaseLayout
+  title={`${displayTitle} — CodingCat.dev`}
+  description={displayDescription}
+  ogImage={ogImage}
+  ogType="article"
+  publishedAt={post.date}
+  author={firstAuthor?.title}
+>
+  <article class="py-12">
+    <Container size="narrow">
+      {/* Header */}
+      <header class="mb-8">
+        <div class="flex items-center gap-3 mb-4">
+          <Badge type="blog" />
+          {formattedDate && (
+            <time datetime={post.date} class="text-sm text-[--text-tertiary]">{formattedDate}</time>
+          )}
+        </div>
 
-    {coverUrl && (
-      <img
-        src={coverUrl}
-        alt={post.title}
-        width={1200}
-        height={630}
-        class="w-full rounded-lg mb-8"
-      />
-    )}
+        <h1 class="text-4xl md:text-5xl font-bold text-[--text] mb-4">{post.title}</h1>
 
-    {post.youtube && (
-      <div class="aspect-video mb-8">
-        <iframe
-          src={`https://www.youtube.com/embed/${post.youtube}`}
-          class="w-full h-full rounded-lg"
-          allowfullscreen
-          loading="lazy"
+        {post.excerpt && (
+          <p class="text-lg text-[--text-secondary] mb-6">{post.excerpt}</p>
+        )}
+
+        {/* Author + Categories */}
+        <div class="flex flex-wrap items-center gap-4">
+          {post.author?.map((a: any) => {
+            const aImg = a.coverImage ? urlForImage(a.coverImage).width(48).height(48).url() : undefined;
+            return (
+              <a href={`/author/${a.slug}`} class="flex items-center gap-2 hover:text-primary transition-colors">
+                <Avatar src={aImg} name={a.title} size="sm" />
+                <span class="text-sm font-medium text-[--text-secondary]">{a.title}</span>
+              </a>
+            );
+          })}
+
+          {post.categories && post.categories.length > 0 && (
+            <div class="flex flex-wrap gap-1.5">
+              {post.categories.map((cat: any) => (
+                <Tag label={cat.title} href={`/topic/${cat.slug}`} />
+              ))}
+            </div>
+          )}
+        </div>
+      </header>
+
+      {/* Cover Image */}
+      {coverUrl && (
+        <img
+          src={coverUrl}
+          alt={post.title}
+          width={1200}
+          height={630}
+          class="w-full rounded-xl mb-8 aspect-video object-cover"
         />
-      </div>
-    )}
+      )}
 
-    <div class="prose prose-lg max-w-none">
-      {post.content && <PortableText value={post.content} />}
-    </div>
+      {/* YouTube Embed */}
+      {post.youtube && (
+        <div class="aspect-video mb-8 rounded-xl overflow-hidden">
+          <iframe
+            src={`https://www.youtube.com/embed/${post.youtube}`}
+            class="w-full h-full"
+            allowfullscreen
+            loading="lazy"
+          />
+        </div>
+      )}
 
-    {post.tags && post.tags.length > 0 && (
-      <div class="mt-8 flex flex-wrap gap-2">
-        {post.tags.map((tag: string) => (
-          <span class="px-3 py-1 bg-gray-100 rounded-full text-sm">{tag}</span>
-        ))}
+      {/* Content */}
+      <div class="prose prose-lg prose-invert max-w-none
+        prose-headings:text-[--text] prose-headings:font-bold
+        prose-p:text-[--text-secondary]
+        prose-a:text-primary prose-a:no-underline hover:prose-a:underline
+        prose-strong:text-[--text]
+        prose-code:text-primary prose-code:bg-[--surface] prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded
+        prose-pre:bg-[--surface] prose-pre:border prose-pre:border-[--border] prose-pre:rounded-xl
+        prose-blockquote:border-primary prose-blockquote:text-[--text-secondary]
+        prose-li:text-[--text-secondary]
+        prose-img:rounded-xl
+      ">
+        {post.content && <PortableText value={post.content} />}
       </div>
-    )}
+
+      {/* Tags */}
+      {post.tags && post.tags.length > 0 && (
+        <div class="mt-12 pt-8 border-t border-[--border]">
+          <h3 class="text-sm font-semibold text-[--text-tertiary] uppercase tracking-wider mb-3">Tags</h3>
+          <div class="flex flex-wrap gap-2">
+            {post.tags.map((tag: string) => (
+              <Tag label={tag} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Author Card */}
+      {firstAuthor && (
+        <div class="mt-12 pt-8 border-t border-[--border]">
+          <a href={`/author/${firstAuthor.slug}`} class="flex items-center gap-4 p-4 rounded-xl bg-[--surface] border border-[--border] hover:border-[--border-hover] transition-colors">
+            <Avatar src={authorImageUrl} name={firstAuthor.title} size="lg" />
+            <div>
+              <p class="font-semibold text-[--text]">{firstAuthor.title}</p>
+              <p class="text-sm text-[--text-secondary]">View all posts →</p>
+            </div>
+          </a>
+        </div>
+      )}
+    </Container>
   </article>
 </BaseLayout>

--- a/apps/web/src/pages/sponsor/[slug].astro
+++ b/apps/web/src/pages/sponsor/[slug].astro
@@ -1,7 +1,8 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
+import Container from "@/components/Container.astro";
 import PersonDetail from "@/components/PersonDetail.astro";
-import { loadQuery } from "@/utils/sanity";
+import { loadQuery, urlForImage } from "@/utils/sanity";
 import { sponsorQuery } from "@/lib/queries";
 
 export const prerender = false;
@@ -13,10 +14,19 @@ const { data: sponsor } = await loadQuery<any>({ query: sponsorQuery, params: { 
 if (!sponsor) {
   return Astro.redirect("/404");
 }
+
+const siteUrl = Astro.url.origin;
+const displayTitle = sponsor.ogTitle || sponsor.title;
+const displayDescription = sponsor.ogDescription || sponsor.excerpt;
+const ogImage = sponsor.ogImage
+  ? urlForImage(sponsor.ogImage).width(1200).height(630).url()
+  : `${siteUrl}/api/og/default.png?title=${encodeURIComponent(sponsor.title)}&subtitle=${encodeURIComponent("Sponsor of CodingCat.dev")}`;
 ---
 
-<BaseLayout title={`${sponsor.title} — CodingCat.dev`} description={sponsor.excerpt}>
-  <main class="container mx-auto px-4 py-8 max-w-4xl">
-    <PersonDetail person={sponsor} type="sponsor" />
+<BaseLayout title={`${displayTitle} — CodingCat.dev`} description={displayDescription} ogImage={ogImage}>
+  <main class="py-12">
+    <Container>
+      <PersonDetail person={sponsor} type="sponsor" />
+    </Container>
   </main>
 </BaseLayout>

--- a/apps/web/src/pages/sponsors.astro
+++ b/apps/web/src/pages/sponsors.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from "@/layouts/BaseLayout.astro";
+import Container from "@/components/Container.astro";
 import ContentCard from "@/components/ContentCard.astro";
 import Pagination from "@/components/Pagination.astro";
 import { loadQuery, sanityFetch } from "@/utils/sanity";
@@ -24,27 +25,34 @@ const totalPages = Math.ceil(totalCount / perPage);
 if (page > totalPages && totalPages > 0) {
   return Astro.redirect(`/sponsors?page=${totalPages}`);
 }
+
+const siteUrl = Astro.url.origin;
+const ogImage = `${siteUrl}/api/og/default.png?title=${encodeURIComponent("Sponsors")}&subtitle=${encodeURIComponent("Supporting CodingCat.dev")}`;
 ---
 
-<BaseLayout title="Sponsors — CodingCat.dev">
-  <main class="container mx-auto px-4 py-8">
-    <h1 class="text-4xl font-bold mb-2">Sponsors</h1>
-    <p class="text-gray-600 mb-8">The sponsors supporting CodingCat.dev content.</p>
+<BaseLayout title="Sponsors — CodingCat.dev" ogImage={ogImage}>
+  <main class="py-12">
+    <Container>
+      <div class="mb-8">
+        <h1 class="text-4xl font-bold text-[--text] mb-2">Sponsors</h1>
+        <p class="text-[--text-secondary] text-lg">The sponsors supporting CodingCat.dev content.</p>
+      </div>
 
-    <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-      {items?.map((item) => (
-        <ContentCard
-          title={item.title}
-          slug={`/sponsor/${item.slug}`}
-          coverImage={item.coverImage}
-          excerpt={item.excerpt}
-          date={item.date}
-        />
-      ))}
-    </div>
+      <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {items?.map((item: any) => (
+          <ContentCard
+            title={item.title}
+            url={`/sponsor/${item.slug}`}
+            type="blog"
+            thumbnail={item.coverImage}
+            metadata={item.date ? new Date(item.date).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" }) : undefined}
+          />
+        ))}
+      </div>
 
-    {totalPages > 1 && (
-      <Pagination currentPage={page} totalPages={totalPages} basePath="/sponsors" />
-    )}
+      {totalPages > 1 && (
+        <Pagination currentPage={page} totalPages={totalPages} basePath="/sponsors" />
+      )}
+    </Container>
   </main>
 </BaseLayout>


### PR DESCRIPTION
# Track C: Page Redesigns

Full page redesign using Track B design system components + Track A schema fields. 17 files changed, +963/-366.

## What Changed

### GROQ Queries (`queries.ts`)
| Field | Added To |
|-------|----------|
| `authorName`, `authorImage` | `baseFields` (all content cards) |
| `categories[]->` | `postListQuery`, `postQuery` |
| `episode`, `season` | `podcastListQuery` |
| `chapters[]`, `series->`, `listenLinks[]` | `podcastFields` |
| `company`, `role` | `authorQuery`, `guestQuery` |
| `socialPreview` (ogTitle, ogDescription, ogImage) | All detail queries |

### BaseLayout
- Integrated `SocialMeta.astro` for `og:*`/`twitter:*` meta tags
- Extended Props: `ogImage`, `ogType`, `publishedAt`, `author`, `canonicalUrl`
- SocialMeta has smart defaults: fallback OG image via `/api/og/default.png`, fallback URL via `Astro.url.href`

### Homepage
- **Hero section**: gradient background, "CodingCat.dev" with `.dev` in primary color, CTA buttons
- **Featured latest podcast**: `ContentCardFeatured` with excerpt + author
- **4 content rows**: Latest Podcasts, Top Podcasts, From the Blog, Top Posts
- Each row: `Badge` header + "View All →" link + 4-column `ContentCard` grid

### Blog Listing + Post Detail
- **Listing**: `Container`, `Badge` header, post count, categories as `Tag` components
- **Detail**: `Badge` + date + author `Avatar` + categories, prose with design tokens, author card at bottom
- **socialPreview**: `ogTitle`/`ogDescription` override defaults when set in Sanity
- **OG image**: `/api/og/blog.png?title=...&author=...`

### Podcast Listing + Episode Detail
- **Listing**: `Container`, `Badge` header, episode/season in metadata
- **Detail** (major upgrade):
  - Series info card (if `podcast.series` exists)
  - Chapters timeline with timestamps and descriptions
  - Guest cards with `Avatar`, company, role, link to guest page
  - Listen links (Spotify, Apple Podcasts, etc.)
  - Picks section with design tokens
  - **OG image**: `/api/og/podcast.png?title=...&author=...&episodeNumber=...`

### Person Pages (Author, Guest, Sponsor)
- **PersonDetail component**: design tokens, company/role display, `ContentCard` new interface, `Badge` headers for related content
- **All detail pages**: socialPreview support, OG images
- **All listing pages**: `Container`, design tokens, OG images

### 404 Page
- Gradient "404" text (primary color)
- Cat-themed message: "This page has gone on a catnap. 😸"
- `Button` components (primary + secondary)

### Generic Pages (`[slug].astro`)
- `Container` narrow, design tokens, OG image

## Design System Compliance
- ✅ **Zero hardcoded colors** — no `text-gray-*`, `bg-gray-*`, `text-blue-*` anywhere
- ✅ All pages use design tokens (`--text`, `--surface`, `--border`, `--color-type-*`)
- ✅ All `ContentCard` usage updated to new interface (`url`, `type`, `thumbnail`, `authorName`, `authorImage`, `metadata`)
- ✅ All pages have `export const prerender = false` (SSR)
- ✅ Prose styling uses design tokens for headings, links, code blocks, blockquotes

## Dependencies
- **Track A** (PR #680, merged ✅): Schema fields — categories, chapters, series, listenLinks, socialPreview, company, role
- **Track B** (PR #679, merged ✅): Design system — Container, ContentCard variants, Badge, Avatar, Tag, Button, ThemeScript
- **Track D** (PR #681, draft): OG image endpoints — `/api/og/blog.png`, `/api/og/podcast.png`, `/api/og/default.png`

## Note on SocialMeta
This PR includes a `SocialMeta.astro` component. Track D (PR #681) also has one. This version is more complete (smart defaults, `og:site_name`, `twitter:site`). When both merge to dev, keep this version.

## Build
✅ 15.46s — clean build, only pre-existing chunk size warning.